### PR TITLE
Add bus mapping lookup in `POP`

### DIFF
--- a/specs/opcode/50POP.md
+++ b/specs/opcode/50POP.md
@@ -4,8 +4,7 @@
 
 A stack initalize empty with stack pointer to 1024, pop operation can only happen when stack is not empty, and it will increase by 1 of stack pointer.
 
-The poped value will be dropped directly without no any more checking & utilizing.
-
+Even the popped value will never be used, it still does lookup to ensure the stack pointer is in range, since we don't explicitly verify stack pointer is in range each step, we instead let state circuit to verify that.
 
 ## Constraints
 
@@ -15,6 +14,8 @@ The poped value will be dropped directly without no any more checking & utilizin
     - stack_pointer + 1
     - pc + 1
     - gas + 2
+3. Lookups: 1 busmapping lookups
+   - A value is indeed at the top of the stack
 
 ## Exceptions
 


### PR DESCRIPTION
There is an issue in original `POP`'s spec: it increases the `global_counter` even it doesn't do bus mapping lookup. This breaks the requirement that each `global_counter` corresponds to an expected read-write in state circuit. (Imagine that a malicious prover could use this non-used `global_counter` to insert unexpected write in state circuit)

However, if we don't do the bus mapping lookup, we can't ensure that `0 <= stack_pointer < 1024` at this step, since we assume the state circuit will verify that. (Imagine that a contract starts with `POP` and then `STOP` immediately, which would pass the verification)

So there are 2 approach to fix this:

1. Do the bus mapping lookup to verify `stack_pointer` is in range
2. Explicitly do range check on `stack_pointer`

After some consideration, I think since we are already outsourcing the effort of verify `stack_pointer` is in range, then we should just use approach 1. to reduce the overall validity check.