### PR TITLE
Fix `BeginTx` and `EndTx` step state transition

### DIFF
--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -101,8 +101,6 @@ def begin_tx(instruction: Instruction):
             state_write_counter=Transition.to(2),
         )
 
-        assert instruction.next is not None
-
         # Constrain either:
         # - is_empty_code and is_to_end_tx
         # - (not is_empty_code) and (not is_to_end_tx)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -76,7 +76,7 @@ def begin_tx(instruction: Instruction):
             # Do step state transition
             instruction.constrain_equal(instruction.next.execution_state, ExecutionState.EndTx)
             instruction.constrain_step_state_transition(
-                rw_counter=Transition.delta(9),
+                rw_counter=Transition.delta(9), call_id=Transition.to(call_id)
             )
         else:
 

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -47,5 +47,7 @@ def end_tx(instruction: Instruction):
 
     # When to end of block
     if instruction.next.execution_state == ExecutionState.EndBlock:
-        # Do step state transition for rw_counter
-        instruction.constrain_step_state_transition(rw_counter=Transition.delta(4))
+        # Do step state transition for rw_counter and call_id
+        instruction.constrain_step_state_transition(
+            rw_counter=Transition.delta(4), call_id=Transition.same()
+        )

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -33,8 +33,6 @@ def end_tx(instruction: Instruction):
     coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
     instruction.add_balance(coinbase, [reward])
 
-    assert instruction.next is not None
-
     # When to next transaction
     if instruction.next.execution_state == ExecutionState.BeginTx:
         # Check next tx_id is increased by 1

--- a/src/zkevm_specs/evm/execution/memory_copy.py
+++ b/src/zkevm_specs/evm/execution/memory_copy.py
@@ -31,7 +31,6 @@ def copy_to_memory(instruction: Instruction):
     instruction.constrain_zero((1 - lt) * (1 - finished))
 
     if finished == 0:
-        assert instruction.next is not None
         next_aux = instruction.next.aux_data
 
         assert isinstance(next_aux, CopyToMemoryAuxData)

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -93,7 +93,7 @@ class Instruction:
     randomness: FQ
     tables: Tables
     curr: StepState
-    next: Optional[StepState]
+    next: StepState
 
     # meta information
     is_first_step: bool
@@ -110,7 +110,7 @@ class Instruction:
         randomness: FQ,
         tables: Tables,
         curr: StepState,
-        next: Optional[StepState],
+        next: StepState,
         is_first_step: bool,
         is_last_step: bool,
     ) -> None:

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import List
 
 from ..util import FQ
 from .execution import EXECUTION_STATE_IMPL
@@ -8,16 +8,20 @@ from .step import StepState
 from .table import Tables
 
 
+DUMMY_STEP_STATE = StepState(ExecutionState.EndBlock, rw_counter=-1)
+
+
 def verify_steps(
     randomness: FQ,
     tables: Tables,
-    steps: Sequence[StepState],
+    steps: List[StepState],
     begin_with_first_step: bool = False,
     end_with_last_step: bool = False,
 ):
-    for idx in range(len(steps) - 1 + end_with_last_step):
-        curr, next = steps[idx], None if len(steps) == idx + 1 else steps[idx + 1]
+    if end_with_last_step:
+        steps.append(DUMMY_STEP_STATE)
 
+    for idx, (curr, next) in enumerate(zip(steps, steps[1:])):
         verify_step(
             Instruction(
                 randomness=randomness,
@@ -25,7 +29,7 @@ def verify_steps(
                 curr=curr,
                 next=next,
                 is_first_step=begin_with_first_step and idx == 0,
-                is_last_step=end_with_last_step and next is None,
+                is_last_step=end_with_last_step and idx == len(steps) - 2,
             )
         )
 
@@ -34,12 +38,12 @@ def verify_step(instruction: Instruction):
     if instruction.is_first_step:
         instruction.constrain_equal(instruction.curr.execution_state, ExecutionState.BeginTx)
 
-    if instruction.curr.execution_state in EXECUTION_STATE_IMPL:
-        EXECUTION_STATE_IMPL[instruction.curr.execution_state](instruction)
-    else:
-        raise NotImplementedError
-
     if instruction.is_last_step:
         instruction.constrain_equal(instruction.curr.execution_state, ExecutionState.EndBlock)
     else:
         instruction.constrain_execution_state_transition()
+
+    if instruction.curr.execution_state in EXECUTION_STATE_IMPL:
+        EXECUTION_STATE_IMPL[instruction.curr.execution_state](instruction)
+    else:
+        raise NotImplementedError

--- a/src/zkevm_specs/evm/precompiled.py
+++ b/src/zkevm_specs/evm/precompiled.py
@@ -7,7 +7,7 @@ class PrecompiledAddress(IntEnum):
     RIPEMD160 = 0x03
     DATA_COPY = 0x04
     BIG_MOD_EXP = 0x05
-    BN254_Add = 0x06
+    BN254_ADD = 0x06
     BN254_SCALAR_MUL = 0x07
     BN254_PAIRING = 0x08
     BLAKE2F = 0x09

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -104,38 +104,41 @@ def test_begin_tx(tx: Transaction, callee: Account, is_success: bool):
 
     bytecode_hash = RLC(callee.code_hash(), randomness)
 
+    # fmt: off
+    rw_dictionary = (
+        RWDictionary(1)
+        .call_context_read(1, CallContextFieldTag.TxId, tx.id)
+        .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_success else rw_counter_end_of_reversion)
+        .call_context_read(1, CallContextFieldTag.IsPersistent, is_success)
+        .account_write(tx.caller_address, AccountFieldTag.Nonce, tx.nonce + 1, tx.nonce)
+        .tx_access_list_account_write(tx.id, tx.caller_address, True, False)
+        .tx_access_list_account_write(tx.id, tx.callee_address, True, False)
+        .account_write(tx.caller_address, AccountFieldTag.Balance, RLC(caller_balance, randomness), RLC(caller_balance_prev, randomness), rw_counter_of_reversion=None if is_success else rw_counter_end_of_reversion)
+        .account_write(tx.callee_address, AccountFieldTag.Balance, RLC(callee_balance, randomness), RLC(callee_balance_prev, randomness), rw_counter_of_reversion=None if is_success else rw_counter_end_of_reversion - 1)
+        .account_read(tx.callee_address, AccountFieldTag.CodeHash, bytecode_hash)
+    )
+    if callee.code_hash() != EMPTY_CODE_HASH:
+        rw_dictionary \
+        .call_context_read(1, CallContextFieldTag.Depth, 1) \
+        .call_context_read(1, CallContextFieldTag.CallerAddress, tx.caller_address) \
+        .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address) \
+        .call_context_read(1, CallContextFieldTag.CallDataOffset, 0) \
+        .call_context_read(1, CallContextFieldTag.CallDataLength, len(tx.call_data)) \
+        .call_context_read(1, CallContextFieldTag.Value, RLC(tx.value, randomness)) \
+        .call_context_read(1, CallContextFieldTag.IsStatic, 0) \
+        .call_context_read(1, CallContextFieldTag.LastCalleeId, 0) \
+        .call_context_read(1, CallContextFieldTag.LastCalleeReturnDataOffset, 0) \
+        .call_context_read(1, CallContextFieldTag.LastCalleeReturnDataLength, 0) \
+        .call_context_read(1, CallContextFieldTag.IsRoot, True) \
+        .call_context_read(1, CallContextFieldTag.IsCreate, False) \
+        .call_context_read(1, CallContextFieldTag.CodeSource, bytecode_hash)
+    # fmt: on
+
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),
         tx_table=set(tx.table_assignments(randomness)),
         bytecode_table=set(callee.code.table_assignments(randomness)),
-        rw_table=set(
-            # fmt: off
-            RWDictionary(1)
-            .call_context_read(1, CallContextFieldTag.TxId, tx.id)
-            .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_success else rw_counter_end_of_reversion)
-            .call_context_read(1, CallContextFieldTag.IsPersistent, is_success)
-            .account_write(tx.caller_address, AccountFieldTag.Nonce, tx.nonce + 1, tx.nonce)
-            .tx_access_list_account_write(tx.id, tx.caller_address, True, False)
-            .tx_access_list_account_write(tx.id, tx.callee_address, True, False)
-            .account_write(tx.caller_address, AccountFieldTag.Balance, RLC(caller_balance, randomness), RLC(caller_balance_prev, randomness), rw_counter_of_reversion=None if is_success else rw_counter_end_of_reversion)
-            .account_write(tx.callee_address, AccountFieldTag.Balance, RLC(callee_balance, randomness), RLC(callee_balance_prev, randomness), rw_counter_of_reversion=None if is_success else rw_counter_end_of_reversion - 1)
-            .account_read(tx.callee_address, AccountFieldTag.CodeHash, bytecode_hash)
-            .call_context_read(1, CallContextFieldTag.Depth, 1)
-            .call_context_read(1, CallContextFieldTag.CallerAddress, tx.caller_address)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address)
-            .call_context_read(1, CallContextFieldTag.CallDataOffset, 0)
-            .call_context_read(1, CallContextFieldTag.CallDataLength, len(tx.call_data))
-            .call_context_read(1, CallContextFieldTag.Value, RLC(tx.value, randomness))
-            .call_context_read(1, CallContextFieldTag.IsStatic, 0)
-            .call_context_read(1, CallContextFieldTag.LastCalleeId, 0)
-            .call_context_read(1, CallContextFieldTag.LastCalleeReturnDataOffset, 0)
-            .call_context_read(1, CallContextFieldTag.LastCalleeReturnDataLength, 0)
-            .call_context_read(1, CallContextFieldTag.IsRoot, True)
-            .call_context_read(1, CallContextFieldTag.IsCreate, False)
-            .call_context_read(1, CallContextFieldTag.CodeSource, bytecode_hash)
-            .rws,
-            # fmt: on
-        ),
+        rw_table=set(rw_dictionary.rws),
     )
 
     verify_steps(
@@ -150,7 +153,7 @@ def test_begin_tx(tx: Transaction, callee: Account, is_success: bool):
                 execution_state=ExecutionState.EndTx
                 if callee.code_hash() == EMPTY_CODE_HASH
                 else ExecutionState.PUSH,
-                rw_counter=23,
+                rw_counter=rw_dictionary.rw_counter,
                 call_id=1,
                 is_root=True,
                 is_create=False,

--- a/tests/evm/test_end_tx.py
+++ b/tests/evm/test_end_tx.py
@@ -95,6 +95,7 @@ def test_end_tx(tx: Transaction, gas_left: int, refund: int, is_last_tx: bool):
             StepState(
                 execution_state=ExecutionState.EndBlock if is_last_tx else ExecutionState.BeginTx,
                 rw_counter=22 - is_last_tx,
+                call_id=1 if is_last_tx else 0,
             ),
         ],
     )


### PR DESCRIPTION
This PR aims to fix the step state transition of `BeginTx` and `EndTx`, it includes:

- Enforce `BeginTx` to `EndTx` when callee with empty code
- Enforce `EndTx` to `EndBlock` has the same `call_id`

Also it removes the optional final state (by using a dummy step state), which is annoying for us to write `assert next_step is not None`