### PR TITLE
CALLDATALOAD: refactor

### DIFF
--- a/specs/opcode/35CALLDATALOAD.md
+++ b/specs/opcode/35CALLDATALOAD.md
@@ -13,7 +13,7 @@ Stack input is the byte offset to read call data from. Stack output is a 32-byte
 1. opId == 0x35
 2. State Transition:
    - if is_root_call:
-     - rw_counter += 3 (1 stack read, 1 call context read, 1 stack write)
+     - rw_counter += 4 (1 stack read, 2 call context read, 1 stack write)
    - if is_internal_call:
      - rw_counter += rw_counter_offset ∈ {5, 6, ..., 36, 37} (1 stack read, 3 call context reads, i ∈ {0, 1, ..., 31, 32} memory reads, 1 stack write)
    - stack_pointer unchanged
@@ -21,9 +21,9 @@ Stack input is the byte offset to read call data from. Stack output is a 32-byte
    - gas - 3
 3. Lookups:
    - `offset` is at the top of the stack
-   - `tx_id` is in the RW table (call context)
    - if is_root_call (where `src_addr = offset`):
-     - `calldata_length` is in the TX table
+     - `tx_id` is in the RW table (call context)
+     - `calldata_length` is in the RW table (call context)
      - i ∈ {0, 1, ..., 31, 32} lookups for `i in range(32)`: if `buffer.read_flag(i)` then the i'th byte of the element on top of the stack `calldata_word[i]` is in the TX table {tx id, call data, src_addr + i}
    - if is_internal_call (where `src_addr = offset + calldata_offset`):
      - `calldata_length` is in the RW table (call context)

--- a/tests/evm/test_calldataload.py
+++ b/tests/evm/test_calldataload.py
@@ -88,14 +88,15 @@ def test_calldataload(
         parent_call_id = 1
 
     rw_dictionary = (
-        RWDictionary(1)
-        .stack_write(call_id, 1023, offset_rlc)
-        .stack_read(call_id, 1023, offset_rlc)
-        .call_context_read(call_id, CallContextFieldTag.TxId, 1)
+        RWDictionary(1).stack_write(call_id, 1023, offset_rlc).stack_read(call_id, 1023, offset_rlc)
     )
     if is_root:
-        rw_dictionary.stack_write(call_id, 1023, expected_stack_top)
+        rw_dictionary.call_context_read(call_id, CallContextFieldTag.TxId, 1).call_context_read(
+            call_id, CallContextFieldTag.CallDataLength, call_data_length
+        ).stack_write(call_id, 1023, expected_stack_top)
     else:
+        # add to RW table call context, caller'd ID (read)
+        rw_dictionary.call_context_read(call_id, CallContextFieldTag.CallerId, parent_call_id)
         # add to RW table call context, call data length (read)
         rw_dictionary.call_context_read(
             call_id, CallContextFieldTag.CallDataLength, call_data_length
@@ -104,8 +105,6 @@ def test_calldataload(
         rw_dictionary.call_context_read(
             call_id, CallContextFieldTag.CallDataOffset, call_data_offset
         )
-        # add to RW table call context, caller'd ID (read)
-        rw_dictionary.call_context_read(call_id, CallContextFieldTag.CallerId, parent_call_id)
         # add to RW table memory (read)
         for i in range(0, len(call_data)):
             idx = offset + call_data_offset + i


### PR DESCRIPTION
- Instead of `tx_id` for root call and `caller_id` for internal call, unify by denoting both as `src_id`.
    - `src_id` is `call.tx_id` for root call
    - `src_id` is `call.caller_id` for internal call
- Update specs
- Update tests

The refactoring takes inspiration from https://github.com/appliedzkp/zkevm-specs/pull/178, simplifying the specs as well as implementation. The circuit allocates one less cell.