### PR TITLE
add `TxReceipt` constraint in begin&end tx

### DIFF
--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -7,6 +7,8 @@ from ..table import CallContextFieldTag, TxContextFieldTag, AccountFieldTag
 
 def begin_tx(instruction: Instruction):
     call_id = instruction.curr.rw_counter
+    log_id = instruction.curr.log_id
+    instruction.constrain_zero(log_id)
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=call_id)
     reversion_info = instruction.reversion_info(call_id=call_id)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -7,8 +7,6 @@ from ..table import CallContextFieldTag, TxContextFieldTag, AccountFieldTag
 
 def begin_tx(instruction: Instruction):
     call_id = instruction.curr.rw_counter
-    log_id = instruction.curr.log_id
-    instruction.constrain_zero(log_id)
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=call_id)
     reversion_info = instruction.reversion_info(call_id=call_id)
@@ -114,5 +112,6 @@ def begin_tx(instruction: Instruction):
                 is_create=Transition.to(False),
                 code_source=Transition.to(code_hash),
                 gas_left=Transition.to(gas_left),
-                state_write_counter=Transition.to(2),
+                reversible_write_counter=Transition.to(2),
+                log_id=Transition.to(0),
             )

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -114,5 +114,5 @@ def begin_tx(instruction: Instruction):
                 is_create=Transition.to(False),
                 code_source=Transition.to(code_hash),
                 gas_left=Transition.to(gas_left),
-                reversible_write_counter=Transition.to(2),
+                state_write_counter=Transition.to(2),
             )

--- a/src/zkevm_specs/evm/execution/call.py
+++ b/src/zkevm_specs/evm/execution/call.py
@@ -198,5 +198,6 @@ def call(instruction: Instruction):
             is_create=Transition.to(False),
             code_source=Transition.to(callee_code_hash),
             gas_left=Transition.to(callee_gas_left),
-            state_write_counter=Transition.to(2),
+            reversible_write_counter=Transition.to(2),
+            log_id=Transition.same(),
         )

--- a/src/zkevm_specs/evm/execution/call.py
+++ b/src/zkevm_specs/evm/execution/call.py
@@ -198,5 +198,5 @@ def call(instruction: Instruction):
             is_create=Transition.to(False),
             code_source=Transition.to(callee_code_hash),
             gas_left=Transition.to(callee_gas_left),
-            reversible_write_counter=Transition.to(2),
+            state_write_counter=Transition.to(2),
         )

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -1,7 +1,7 @@
 from ...util import N_BYTES_GAS, MAX_REFUND_QUOTIENT_OF_GAS_USED, FQ, RLC, cast_expr
 from ..execution_state import ExecutionState
 from ..instruction import Instruction, Transition
-from ..table import BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag
+from ..table import BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag, TxReceiptFieldTag
 
 
 def end_tx(instruction: Instruction):
@@ -33,6 +33,9 @@ def end_tx(instruction: Instruction):
     coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
     instruction.add_balance(coinbase, [reward])
 
+    # constrain log id matches with `LogLength` of TxReceipt tag in RW
+    log_id = instruction.tx_receipt_lookup(tx_id, TxReceiptFieldTag.LogLength)
+    instruction.constrain_equal(log_id, instruction.curr.log_id)
     # When to next transaction
     if instruction.next.execution_state == ExecutionState.BeginTx:
         # Check next tx_id is increased by 1

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -45,14 +45,14 @@ def end_tx(instruction: Instruction):
 
     # constrain `CumulativeGasUsed` of TxReceipt tag in RW
     if tx_id == 1:  # check if it is the first tx
-        pre_tx_gas_cumulate = FQ(0)
+        current_cumulative_gas_used = FQ(0)
     else:
-        pre_tx_gas_cumulate = instruction.tx_receipt_lookup(
+        current_cumulative_gas_used = instruction.tx_receipt_lookup(
             tx_id - FQ(1), TxReceiptFieldTag.CumulativeGasUsed
         ).expr()
 
     instruction.constrain_equal(
-        pre_tx_gas_cumulate + gas_used,
+        current_cumulative_gas_used + gas_used,
         instruction.tx_receipt_lookup(tx_id, TxReceiptFieldTag.CumulativeGasUsed),
     )
 

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -44,7 +44,8 @@ def end_tx(instruction: Instruction):
     instruction.constrain_equal(log_id, instruction.curr.log_id)
 
     # constrain `CumulativeGasUsed` of TxReceipt tag in RW
-    if tx_id == 1:  # check if it is the first tx
+    is_first_tx = tx_id == 1
+    if is_first_tx:  # check if it is the first tx
         current_cumulative_gas_used = FQ(0)
     else:
         current_cumulative_gas_used = instruction.tx_receipt_lookup(
@@ -66,11 +67,11 @@ def end_tx(instruction: Instruction):
             tx_id.expr() + 1,
         )
         # Do step state transition for rw_counter
-        instruction.constrain_step_state_transition(rw_counter=Transition.delta(5))
+        instruction.constrain_step_state_transition(rw_counter=Transition.delta(10 - is_first_tx))
 
     # When to end of block
     if instruction.next.execution_state == ExecutionState.EndBlock:
         # Do step state transition for rw_counter and call_id
         instruction.constrain_step_state_transition(
-            rw_counter=Transition.delta(4), call_id=Transition.same()
+            rw_counter=Transition.delta(9 - is_first_tx), call_id=Transition.same()
         )

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -212,6 +212,7 @@ class Instruction:
         code_source: Transition,
         gas_left: Transition,
         reversible_write_counter: Transition,
+        log_id: Transition,
     ):
         self.constrain_step_state_transition(
             rw_counter=rw_counter,
@@ -221,6 +222,7 @@ class Instruction:
             code_source=code_source,
             gas_left=gas_left,
             reversible_write_counter=reversible_write_counter,
+            log_id=log_id,
             # Initailization unconditionally
             program_counter=Transition.to(0),
             stack_pointer=Transition.to(1024),

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -462,14 +462,12 @@ class Instruction:
         ).value
         return value
 
-        # look up tx log fields (Data, Address, Topic),
-
+    # look up TxReceipt fields (PostStateOrStatus, CumulativeGasUsed, LogLength)
     def tx_receipt_lookup(
         self,
         tx_id: Expression,
         field_tag: TxReceiptFieldTag,
     ) -> Expression:
-        # evm only write tx log
         value = self.rw_lookup(
             RW.Read,
             RWTableTag.TxReceipt,

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -33,6 +33,7 @@ from .table import (
     RW,
     RWTableTag,
     TxLogFieldTag,
+    TxReceiptFieldTag,
 )
 
 
@@ -458,6 +459,24 @@ class Instruction:
             key2=self.curr.log_id,
             key3=FQ(field_tag),
             key4=FQ(index),
+        ).value
+        return value
+
+        # look up tx log fields (Data, Address, Topic),
+
+    def tx_receipt_lookup(
+        self,
+        tx_id: Expression,
+        field_tag: TxReceiptFieldTag,
+    ) -> Expression:
+        # evm only write tx log
+        value = self.rw_lookup(
+            RW.Read,
+            RWTableTag.TxReceipt,
+            key1=tx_id,
+            key2=FQ(0),
+            key3=FQ(field_tag),
+            key4=FQ(0),
         ).value
         return value
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -28,6 +28,7 @@ from .table import (
     RWTableTag,
     TxContextFieldTag,
     TxLogFieldTag,
+    TxReceiptFieldTag,
     TxTableRow,
 )
 from .opcode import get_push_size, Opcode
@@ -387,6 +388,24 @@ class RWDictionary:
             key2=FQ(log_id),
             key3=FQ(field_tag),
             key4=FQ(index),
+            value=value,
+        )
+
+    def tx_receipt_read(
+        self,
+        tx_id: IntOrFQ,
+        field_tag: TxReceiptFieldTag,
+        value: Union[int, FQ, RLC],
+    ) -> RWDictionary:
+        if isinstance(value, int):
+            value = FQ(value)
+        return self._append(
+            RW.Read,
+            RWTableTag.TxReceipt,
+            key1=FQ(tx_id),
+            key2=FQ(0),
+            key3=FQ(field_tag),
+            key4=FQ(0),
             value=value,
         )
 

--- a/tests/evm/test_end_tx.py
+++ b/tests/evm/test_end_tx.py
@@ -50,9 +50,11 @@ TESTING_DATA = (
 )
 
 
-@pytest.mark.parametrize("tx, gas_left, refund, is_last_tx, pre_tx_gas_cumulate", TESTING_DATA)
+@pytest.mark.parametrize(
+    "tx, gas_left, refund, is_last_tx, current_cumulative_gas_used", TESTING_DATA
+)
 def test_end_tx(
-    tx: Transaction, gas_left: int, refund: int, is_last_tx: bool, pre_tx_gas_cumulate: int
+    tx: Transaction, gas_left: int, refund: int, is_last_tx: bool, current_cumulative_gas_used: int
 ):
     randomness = rand_fq()
 
@@ -78,14 +80,16 @@ def test_end_tx(
 
     # check it is first tx
     if tx.id == 1:
-        assert pre_tx_gas_cumulate == 0
+        assert current_cumulative_gas_used == 0
         rw_dictionary.tx_receipt_read(tx.id, TxReceiptFieldTag.CumulativeGasUsed, tx.gas - gas_left)
     else:
         rw_dictionary.tx_receipt_read(
-            tx.id - 1, TxReceiptFieldTag.CumulativeGasUsed, pre_tx_gas_cumulate
+            tx.id - 1, TxReceiptFieldTag.CumulativeGasUsed, current_cumulative_gas_used
         )
         rw_dictionary.tx_receipt_read(
-            tx.id, TxReceiptFieldTag.CumulativeGasUsed, tx.gas - gas_left + pre_tx_gas_cumulate
+            tx.id,
+            TxReceiptFieldTag.CumulativeGasUsed,
+            tx.gas - gas_left + current_cumulative_gas_used,
         )
 
     if not is_last_tx:

--- a/tests/evm/test_end_tx.py
+++ b/tests/evm/test_end_tx.py
@@ -79,7 +79,8 @@ def test_end_tx(
     )
 
     # check it is first tx
-    if tx.id == 1:
+    is_first_tx = tx.id == 1
+    if is_first_tx:
         assert current_cumulative_gas_used == 0
         rw_dictionary.tx_receipt_read(tx.id, TxReceiptFieldTag.CumulativeGasUsed, tx.gas - gas_left)
     else:
@@ -93,7 +94,7 @@ def test_end_tx(
         )
 
     if not is_last_tx:
-        rw_dictionary.call_context_read(22, CallContextFieldTag.TxId, tx.id + 1)
+        rw_dictionary.call_context_read(27 - is_first_tx, CallContextFieldTag.TxId, tx.id + 1)
 
     tables = Tables(
         block_table=set(block.table_assignments(randomness)),
@@ -120,7 +121,7 @@ def test_end_tx(
             ),
             StepState(
                 execution_state=ExecutionState.EndBlock if is_last_tx else ExecutionState.BeginTx,
-                rw_counter=22 - is_last_tx,
+                rw_counter=27 - is_first_tx - is_last_tx,
                 call_id=1 if is_last_tx else 0,
             ),
         ],

--- a/tests/evm/test_end_tx.py
+++ b/tests/evm/test_end_tx.py
@@ -7,6 +7,7 @@ from zkevm_specs.evm import (
     Tables,
     AccountFieldTag,
     CallContextFieldTag,
+    TxReceiptFieldTag,
     Block,
     Transaction,
     RWDictionary,
@@ -64,6 +65,8 @@ def test_end_tx(tx: Transaction, gas_left: int, refund: int, is_last_tx: bool):
             .tx_refund_read(tx.id, refund)
             .account_write(tx.caller_address, AccountFieldTag.Balance, RLC(caller_balance, randomness), RLC(caller_balance_prev, randomness))
             .account_write(block.coinbase, AccountFieldTag.Balance, RLC(coinbase_balance, randomness), RLC(coinbase_balance_prev, randomness))
+            # TODO: test log id is not zero condition
+            .tx_receipt_read(tx.id, TxReceiptFieldTag.LogLength, 0)
         # fmt: on
     )
     if not is_last_tx:


### PR DESCRIPTION
this PR aims to  resolve issue #177 to add constraint to `TxReceipt` tag.  
- (1) In begin_Tx gadget, log_id should reset to zero at the beginning.
In end_tx gadget, log_id should match with LogLength of TxReceipt RW table. 
- (2) PostStateOrStatus should be equal to tx status in `end_tx`
- (3)  current receipt's `CumulativeGasUsed` =.pre receipt's `CumulativeGasUsed` + current tx gas cost