### PR TITLE
fix copy log data index in multi steps

### DIFF
--- a/src/zkevm_specs/evm/execution/copy_to_log.py
+++ b/src/zkevm_specs/evm/execution/copy_to_log.py
@@ -24,7 +24,10 @@ def copy_to_log(instruction: Instruction):
         # when is_persistent = false, only do memory_lookup, no tx_log_lookup
         if buffer_reader.has_data(i) == 1 and aux.is_persistent == 1:
             instruction.constrain_equal(
-                byte, instruction.tx_log_lookup(aux.tx_id, TxLogFieldTag.Data, i)
+                byte,
+                instruction.tx_log_lookup(
+                    aux.tx_id, TxLogFieldTag.Data, i + aux.data_start_index.n
+                ),
             )
 
     copied_bytes = buffer_reader.num_bytes()
@@ -41,6 +44,10 @@ def copy_to_log(instruction: Instruction):
         instruction.constrain_equal(next_aux.bytes_left + copied_bytes, aux.bytes_left)
         instruction.constrain_equal(next_aux.src_addr_end, aux.src_addr_end)
         instruction.constrain_equal(next_aux.is_persistent, aux.is_persistent)
+        instruction.constrain_equal(next_aux.tx_id, aux.tx_id)
+        instruction.constrain_equal(
+            next_aux.data_start_index, aux.data_start_index + MAX_COPY_BYTES
+        )
 
     instruction.constrain_step_state_transition(
         rw_counter=Transition.delta(instruction.rw_counter_offset),

--- a/src/zkevm_specs/evm/execution/log.py
+++ b/src/zkevm_specs/evm/execution/log.py
@@ -68,6 +68,7 @@ def log(instruction: Instruction):
         instruction.constrain_equal(next_aux.bytes_left, msize)
         instruction.constrain_equal(next_aux.is_persistent, is_persistent)
         instruction.constrain_equal(next_aux.tx_id, tx_id)
+        instruction.constrain_zero(next_aux.data_start_index)
 
     # omit block number constraint even it is set within op code explicitly, because by default the circuit only handle
     # current block, otherwise, block context lookup is required.

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -110,6 +110,7 @@ class CopyToLogAuxData:
     src_addr_end: FQ
     is_persistent: FQ
     tx_id: FQ
+    data_start_index: FQ
 
     def __init__(
         self,
@@ -118,12 +119,14 @@ class CopyToLogAuxData:
         src_addr_end: int,
         is_persistent: int,
         tx_id: int,
+        data_start_index: int,
     ):
         self.src_addr = FQ(src_addr)
         self.bytes_left = FQ(bytes_left)
         self.src_addr_end = FQ(src_addr_end)
         self.is_persistent = FQ(is_persistent)
         self.tx_id = FQ(tx_id)
+        self.data_start_index = FQ(data_start_index)
 
 
 class CopyCodeToMemoryAuxData:

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -87,4 +87,4 @@ SSTORE_CLEARS_SCHEDULE = 4800
 
 # The max number of bytes that can be copied in a step limited by the number
 # of cells in a step
-MAX_COPY_BYTES = 71
+MAX_COPY_BYTES = 32


### PR DESCRIPTION
the circuit fix https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/510 has been merged ,  also change `MAX_COPY_BYTES` to 32 aligning with circuit implementation .