### PR TITLE
revise log id for look up

### DIFF
--- a/src/zkevm_specs/evm/execution/copy_to_log.py
+++ b/src/zkevm_specs/evm/execution/copy_to_log.py
@@ -26,7 +26,10 @@ def copy_to_log(instruction: Instruction):
             instruction.constrain_equal(
                 byte,
                 instruction.tx_log_lookup(
-                    aux.tx_id, TxLogFieldTag.Data, i + aux.data_start_index.n
+                    aux.tx_id,
+                    instruction.curr.log_id,
+                    TxLogFieldTag.Data,
+                    i + aux.data_start_index.n,
                 ),
             )
 

--- a/src/zkevm_specs/evm/execution/log.py
+++ b/src/zkevm_specs/evm/execution/log.py
@@ -30,7 +30,9 @@ def log(instruction: Instruction):
     if instruction.is_zero(is_persistent) == 0:
         instruction.constrain_equal(
             contract_address,
-            instruction.tx_log_lookup(tx_id=tx_id, field_tag=TxLogFieldTag.Address),
+            instruction.tx_log_lookup(
+                tx_id=tx_id, log_id=instruction.curr.log_id + 1, field_tag=TxLogFieldTag.Address
+            ),
         )
 
     # constrain topics in stack & logs
@@ -44,7 +46,10 @@ def log(instruction: Instruction):
                 instruction.constrain_equal(
                     topic.expr(),
                     instruction.tx_log_lookup(
-                        tx_id=tx_id, field_tag=TxLogFieldTag.Topic, index=i
+                        tx_id=tx_id,
+                        log_id=instruction.curr.log_id + 1,
+                        field_tag=TxLogFieldTag.Topic,
+                        index=i,
                     ).expr(),
                 )
 
@@ -76,7 +81,9 @@ def log(instruction: Instruction):
     next_memory_size, memory_expansion_gas = instruction.memory_expansion_dynamic_length(
         mstart, msize
     )
-    dynamic_gas = GAS_COST_LOG * (opcode - Opcode.LOG0) + 8 * msize + memory_expansion_gas
+    dynamic_gas = (
+        GAS_COST_LOG + GAS_COST_LOG * (opcode - Opcode.LOG0) + 8 * msize + memory_expansion_gas
+    )
 
     assert isinstance(is_persistent, FQ)
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -451,14 +451,14 @@ class Instruction:
 
     # look up tx log fields (Data, Address, Topic),
     def tx_log_lookup(
-        self, tx_id: Expression, field_tag: TxLogFieldTag, index: int = 0
+        self, tx_id: Expression, log_id: Expression, field_tag: TxLogFieldTag, index: int = 0
     ) -> Expression:
         # evm only write tx log
         value = self.rw_lookup(
             RW.Write,
             RWTableTag.TxLog,
             key1=tx_id,
-            key2=self.curr.log_id,
+            key2=log_id,
             key3=FQ(field_tag),
             key4=FQ(index),
         ).value

--- a/tests/evm/test_logs.py
+++ b/tests/evm/test_logs.py
@@ -161,7 +161,7 @@ def test_logs(topics: list, mstart: U64, msize: U64, is_persistent: bool):
     data = rand_bytes(msize)
     topic_count = len(topics)
     next_memory_size, memory_expansion_cost = memory_expansion(mstart, msize)
-    dynamic_gas = GAS_COST_LOG * topic_count + 8 * msize + memory_expansion_cost
+    dynamic_gas = GAS_COST_LOG + GAS_COST_LOG * topic_count + 8 * msize + memory_expansion_cost
     bytecode = bytecodes[topic_count]
     bytecode_hash = RLC(bytecode.hash(), randomness)
     tx = Transaction(id=TX_ID, gas=dynamic_gas)
@@ -192,7 +192,7 @@ def test_logs(topics: list, mstart: U64, msize: U64, is_persistent: bool):
     )
 
     if is_persistent:
-        rw_dictionary.tx_log_write(TX_ID, 0, TxLogFieldTag.Address, 0, FQ(CALLEE_ADDRESS))
+        rw_dictionary.tx_log_write(TX_ID, 1, TxLogFieldTag.Address, 0, FQ(CALLEE_ADDRESS))
 
     # append topic rows
     construct_topic_rws(rw_dictionary, 1017, topics, is_persistent, randomness)
@@ -252,7 +252,7 @@ def construct_topic_rws(
         rw_dictionary.stack_read(CALL_ID, sp, RLC(topics[i], randomness, 32))
         if is_persistent:
             rw_dictionary.tx_log_write(
-                TX_ID, 0, TxLogFieldTag.Topic, i, RLC(topics[i], randomness, 32)
+                TX_ID, 1, TxLogFieldTag.Topic, i, RLC(topics[i], randomness, 32)
             )
 
         sp += 1


### PR DESCRIPTION
two minor changes:
1. use next step log_id ( current step 's log_id + 1) to look up logs fields.  
  the reason is only in next copy step, log_id plus 1,  while current step log_id is zero,  however, for the semantic matter, they are belong to the same real step of evm/geth,  so both use next step log_id is reasonable for lookup, which also matched pre defined zero log id meaning no log data executed. 
3. add log static gas , which is done in circuit side https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/507