### PR TITLE
SHA3 opcode | Keccak support in copy circuit

### DIFF
--- a/specs/copy-proof.md
+++ b/specs/copy-proof.md
@@ -15,6 +15,9 @@ In addition to the columns in the copy table, copy circuit adds a few auxiliary 
 - `is_bytecode`: indicates if `Type` is `Bytecode` using `IsZero` gadget.
 - `is_tx_calldata`: indicates if `Type` is `TxCalldata` using `IsZero` gadget.
 - `is_tx_log`: indicates if `Type` is `TxLog` using `IsZero` gadget.
+- `is_rlc_acc`: indicates if `Type` is `RlcAcc` using `IsZero` gadget.
+
+*Note*: We use `IsZero` gadget in the specs for simplicity. In the actual circuit implementation, we make use of `BinaryGadget`.
 
 ## Circuit Constraints
 
@@ -25,14 +28,16 @@ First, the circuit adds common constraints that applied to every rows in the cir
 - Boolean check for `is_first`, and `is_last`
 - Check `is_first == 0` when `q_step == 0`
 - Check `is_last == 0` when `q_step == 1`
-- Construct the IsZero gadget and constrain `is_memory`, `is_bytecode`, `is_tx_calldata`, and `is_tx_log`.
+- Construct the `IsZero` gadget and constrain `is_memory`, `is_bytecode`, `is_tx_calldata`, `is_tx_log` and `is_rlc_acc`.
 - The transition constraints from a copy step to the next step (with 2-row rotation), applied to all rows except the last two rows (the last step) in a copy event:
     - `ID`, `Type`, `AddressEnd` should be same between two steps.
     - `Address` increase by 1 in the next copy step.
 - The transition constraints for `RwCounter` and `RwcIncreaseLeft` column
     - define `rw_diff` to be 1 if the `Type` is `Memory` or `TxLog` and `Padding` is 0 in the current row; otherwise 0.
     - when it's not the last row in a copy event (`is_last == 0`), `RwCounter` increases by `rw_diff` and `RwcIncreaseLeft` decrases by `rw_diff`.
+    - over all rows, the `rlc_acc` remains the same.
     - when it's the last row in a copy event (`is_last == 1`), `RwcIncreaseLeft` is equal to `rw_diff`.
+    - when it's the last row of a copy event (`is_last == 1`) and `is_rlc_acc == 1`, the row `value` should equal the row `rlc_acc`.
 
 Second, the circuit adds the constraints for every copy step in the circuit, when `q_step` is 1.
 
@@ -40,12 +45,18 @@ Second, the circuit adds the constraints for every copy step in the circuit, whe
 - Constrain the transition for `BytesLeft`
     - when it's not the last step (`is_last[1] != 1`), decrease by 1 in the next step
     - otherwise, equals to 1.
-- Constrain the write value equals to read value: `Value[1] == Value`
+- For all cases except `is_rlc_acc == 1`, we have `Value[0] == Value[1]`, meaning that read `value` equates write `value`.
+- For `is_rlc_acc == 1`, we have `Value[0] == Value[1]` only for the first row, i.e. `is_first == 1`.
 - Constrain `Value == 0` when `Padding == 1`.
 - Construct the LT gadget to compare `Address` and `AddressEnd` in the read operation. If `Address >= AddressEnd`, constrain `Padding == 1`
 - Constrain `Padding[1] == 0` as the write operation is never padded.
 
-Third, the circuit adds the lookup arguments to the corresponding tables.
+Third, the circuit adds constraints for every copy step in the circuit, when `q_step == 0` (write row). These constraints are only added for the `is_rlc_acc == 1` case, for all except the last row, i.e. `is_last == 0`.
+
+- Constraint the next write `value` by:
+    - `Value[2] == Value[0] * r + Value[1]`
+
+Fourth, the circuit adds the lookup arguments to the corresponding tables.
 
 - When `Type` is `Memory` or `is_memory == 1` and `Padding == 0`, look up the `Value` to `rw_table` with `Memory` tag.
 - When `Type` is `TxCalldata` or `is_tx_calldata == 1` and `Padding == 0`, look up the `Value` to `tx_table`.

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -282,11 +282,12 @@ The copy table consists of 13 columns, described as follows:
 - **is_first**: a boolean value to indicate the first row in a copy event.
 - **is_last**: a boolean value to indicate the last row in a copy event.
 - **ID**: could be `$txID`, `$callID`, `$codeHash` (RLC encoded).
-- **Type**: indicates the type of data source, including `Memory`, `Bytecode`, `TxCalldata`, `TxLog`.
+- **Type**: indicates the type of data source, including `Memory`, `Bytecode`, `TxCalldata`, `TxLog` and `RlcAcc`.
 - **Address**: indicates the address in the source data, could be memory address, byte index in the bytecode, tx call data, and tx log data. When the data type is `TxLog`, the address is the combination of byte index, `TxLogFieldTag.Data` tag, and `LogID`.
 - **AddressEnd**: indicates the address boundary of the source data. Any data read from address greater than or equal to `AddressEnd` should be 0. Note `AddressEnd` is only valid for read operations or `q_step` is 1.
 - **BytesLeft**: indicates the number of bytes left to be copied.
 - **Value**: indicates the value read or write from source or to the destination.
+- **RlcAcc**: indicates the RLC representation of an accumulator value over all write values.
 - **Pad**: indicates if the value read from the source is padded. Only valid for read operations or `q_step` is 1.
 - **IsCode**: a boolean value to indicate if the `Value` is an executable opcode or the data portion of `PUSH*` operations. Only valid when `Type` is `Bytecode`.
 - **RwCounter**: indicates the current RW counter at this row. This value will be used in the lookup to the `rw_table` when `Type` is  `Memory` or `TxLog`.
@@ -295,7 +296,7 @@ The copy table consists of 13 columns, described as follows:
 
 Unlike other lookup tables, the copy table is a virtual table. The lookup entry is not a single row in the table, and not every row corresponds to a lookup entry.
 Instead, a lookup entry is constructed from the first two rows in each copy event as
-`(is_first, ID, Type, ID[1], Type[1], Address, AddressEnd, Address[1], BytesLeft, RwCounter, RwcIncreaseLeft)`, where `is_first` is 1 and `Column[1]` indicates the next row in the corresponding column.
+`(is_first, ID, Type, ID[1], Type[1], Address, AddressEnd, Address[1], BytesLeft, RlcAcc, RwCounter, RwcIncreaseLeft)`, where `is_first` is 1 and `Column[1]` indicates the next row in the corresponding column.
 
 The table below lists all of copy pairs supported in the copy table:
 - Copy from Tx call data to memory (`CALLDATACOPY`).
@@ -303,20 +304,21 @@ The table below lists all of copy pairs supported in the copy table:
 - Copy from bytecode to memory (`CODECOPY`, `EXTCODECOPY`).
 - Copy from memory to bytecode (`CREATE`, `CREATE2`, `RETURN` (create))
 - Copy from memory to TxLog in the `rw_table` (`LOGX`)
+- Copy from memory to RlcAcc (`SHA3`)
 
-| q_step | q_first | q_last | ID        | Type       | Address        | AddressEnd     | BytesLeft  | Value  | IsCode  | Pad | RwCounter | RwcIncreaseLeft |
-|--------|---------|--------|-----------|------------|----------------|----------------|------------|--------|---------|-----|-----------|-----------------|
-| 1      | 0/1     | 0      | $txID     | TxCalldata | $byteIndex     | $cdLength      | $bytesLeft | $value | -       | 0/1 | -         | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | -       | 0   | $counter  | $rwcIncLeft     |
-|        |         |        |           |            |                |                |            |        |         |     |           |                 |
-| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | -       | 0/1 | $counter  | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | -       | 0   | $counter  | $rwcIncLeft     |
-|        |         |        |           |            |                |                |            |        |         |     |           |                 |
-| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $isCode | 0/1 | $counter  | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $codeHash | Bytecode   | $byteIndex     | -              | -          | $value | $isCode | 0   | -         | $rwcIncLeft     |
-|        |         |        |           |            |                |                |            |        |         |     |           |                 |
-| 1      | 0/1     | 0      | $codeHash | Bytecode   | $byteIndex     | $codeLength    | $bytesLeft | $value | $isCode | 0/1 | -         | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | $isCode | 0   | $counter  | $rwcIncLeft     |
-|        |         |        |           |            |                |                |            |        |         |     |           |                 |
-| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | -       | 0/1 | $counter  | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $txID     | TxLog      | $byteIndex \|\| TxLogData \|\| $logID | -              | -          | $value | -       | 0   | $counter  | $rwcIncLeft     |
+| q_step | q_first | q_last | ID        | Type       | Address        | AddressEnd     | BytesLeft  | Value  | RlcAcc  | IsCode  | Pad | RwCounter | RwcIncreaseLeft |
+|--------|---------|--------|-----------|------------|----------------|----------------|------------|--------|---------|---------|-----|-----------|-----------------|
+| 1      | 0/1     | 0      | $txID     | TxCalldata | $byteIndex     | $cdLength      | $bytesLeft | $value | $rlcAcc | -       | 0/1 | -         | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | $rlcAcc | -       | 0   | $counter  | $rwcIncLeft     |
+|        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
+| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $rlcAcc | -       | 0/1 | $counter  | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | $rlcAcc | -       | 0   | $counter  | $rwcIncLeft     |
+|        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
+| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $rlcAcc | $isCode | 0/1 | $counter  | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $codeHash | Bytecode   | $byteIndex     | -              | -          | $value | $rlcAcc | $isCode | 0   | -         | $rwcIncLeft     |
+|        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
+| 1      | 0/1     | 0      | $codeHash | Bytecode   | $byteIndex     | $codeLength    | $bytesLeft | $value | $rlcAcc | $isCode | 0/1 | -         | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | $rlcAcc | $isCode | 0   | $counter  | $rwcIncLeft     |
+|        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
+| 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $rlcAcc | -       | 0/1 | $counter  | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $txID     | TxLog      | $byteIndex \|\| TxLogData \|\| $logID | -             | $rlcAcc  | -          | $value | -       | 0   | $counter  | $rwcIncLeft     |

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -321,4 +321,4 @@ The table below lists all of copy pairs supported in the copy table:
 | 0      | 0       | 0/1    | $callID   | Memory     | $memoryAddress | -              | -          | $value | $rlcAcc | $isCode | 0   | $counter  | $rwcIncLeft     |
 |        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
 | 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $rlcAcc | -       | 0/1 | $counter  | $rwcIncLeft     |
-| 0      | 0       | 0/1    | $txID     | TxLog      | $byteIndex \|\| TxLogData \|\| $logID | -             | $rlcAcc  | -          | $value | -       | 0   | $counter  | $rwcIncLeft     |
+| 0      | 0       | 0/1    | $txID     | TxLog      | $byteIndex \|\| TxLogData \|\| $logID | - | - | $value | $rlcAcc | -       | 0   | $counter  | $rwcIncLeft     |

--- a/src/zkevm_specs/copy_circuit.py
+++ b/src/zkevm_specs/copy_circuit.py
@@ -50,9 +50,14 @@ def verify_row(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow]):
         # not last row
         cs.constrain_equal(rows[0].rw_counter + rw_diff, rows[1].rw_counter)
         cs.constrain_equal(rows[0].rwc_inc_left - rw_diff, rows[1].rwc_inc_left)
+        # rlc_acc is the same over all rows
+        cs.constrain_equal(rows[0].rlc_acc, rows[1].rlc_acc)
     with cs.condition(rows[0].is_last) as cs:
         # rwc_inc_left == rw_diff for last row in the copy slot
         cs.constrain_equal(rows[0].rwc_inc_left, rw_diff)
+        # for RlcAcc type, value == rlc_acc at the last row
+        with cs.condition(rows[0].is_rlc_acc) as cs:
+            cs.constrain_equal(rows[0].rlc_acc, rows[0].value)
 
 
 def verify_step(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow], r: FQ):

--- a/src/zkevm_specs/copy_circuit.py
+++ b/src/zkevm_specs/copy_circuit.py
@@ -85,7 +85,7 @@ def verify_step(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow], r: FQ):
 
     with cs.condition(1 - rows[0].q_step):
         with cs.condition(1 - rows[0].is_last):
-            # next_write_value == write_value + next_read_value if rlc accumulator
+            # next_write_value == (write_value * r) + next_read_value if rlc accumulator
             with cs.condition(rows[0].is_rlc_acc):
                 cs.constrain_equal(rows[2].value, rows[0].value * r + rows[1].value)
 

--- a/src/zkevm_specs/copy_circuit.py
+++ b/src/zkevm_specs/copy_circuit.py
@@ -33,6 +33,7 @@ def verify_row(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow]):
     cs.constrain_equal(rows[0].is_bytecode, cs.is_zero(rows[0].tag - CopyDataTypeTag.Bytecode))
     cs.constrain_equal(rows[0].is_tx_calldata, cs.is_zero(rows[0].tag - CopyDataTypeTag.TxCalldata))
     cs.constrain_equal(rows[0].is_tx_log, cs.is_zero(rows[0].tag - CopyDataTypeTag.TxLog))
+    cs.constrain_equal(rows[0].is_rlc_acc, cs.is_zero(rows[0].tag - CopyDataTypeTag.RlcAcc))
 
     # constrain the transition between two copy steps
     is_last_two_rows = rows[0].is_last + rows[1].is_last
@@ -60,8 +61,14 @@ def verify_step(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow]):
         cs.constrain_zero(rows[1].is_last * (1 - rows[0].bytes_left))
         # bytes_left == bytes_left_next + 1 for non-last step
         cs.constrain_zero((1 - rows[1].is_last) * (rows[0].bytes_left - rows[2].bytes_left - 1))
-        # write value == read value
-        cs.constrain_equal(rows[0].value, rows[1].value)
+
+        # write value == read value if not rlc accumulator
+        with cs.condition(1 - rows[1].is_rlc_acc):
+            cs.constrain_equal(rows[0].value, rows[1].value)
+        # read value == write value for the first step (always)
+        with cs.condition(rows[0].is_first):
+            cs.constrain_equal(rows[0].value, rows[1].value)
+
         # value == 0 when is_pad == 1 for read
         cs.constrain_zero(rows[0].is_pad * rows[0].value)
         # is_pad == 1 - (src_addr < src_addr_end) for read row
@@ -70,6 +77,12 @@ def verify_step(cs: ConstraintSystem, rows: Sequence[CopyCircuitRow]):
         )
         # is_pad == 0 for write row
         cs.constrain_zero(rows[1].is_pad)
+
+    with cs.condition(1 - rows[0].q_step):
+        with cs.condition(1 - rows[0].is_last):
+            # next_write_value == write_value + next_read_value if rlc accumulator
+            with cs.condition(rows[0].is_rlc_acc):
+                cs.constrain_equal(rows[2].value, rows[1].value + rows[0].value)
 
 
 def verify_copy_table(copy_circuit: CopyCircuit, tables: Tables):

--- a/src/zkevm_specs/evm/execution/__init__.py
+++ b/src/zkevm_specs/evm/execution/__init__.py
@@ -33,6 +33,7 @@ from .storage import *
 from .selfbalance import *
 from .extcodehash import *
 from .log import *
+from .sha3 import sha3
 from .shr import shr
 from .bitwise import not_opcode
 from .sdiv_smod import sdiv_smod
@@ -63,6 +64,7 @@ EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.PUSH: push,
     ExecutionState.SCMP: scmp,
     ExecutionState.GAS: gas,
+    ExecutionState.SHA3: sha3,
     ExecutionState.SLOAD: sload,
     ExecutionState.SSTORE: sstore,
     ExecutionState.SELFBALANCE: selfbalance,

--- a/src/zkevm_specs/evm/execution/calldatacopy.py
+++ b/src/zkevm_specs/evm/execution/calldatacopy.py
@@ -39,7 +39,7 @@ def calldatacopy(instruction: Instruction):
         FQ(instruction.curr.is_root), FQ(CopyDataTypeTag.TxCalldata), FQ(CopyDataTypeTag.Memory)
     )
     if instruction.is_zero(length) == 0:
-        copy_rwc_inc = instruction.copy_lookup(
+        copy_rwc_inc, _ = instruction.copy_lookup(
             src_id,
             CopyDataTypeTag(src_type.n),
             instruction.curr.call_id,

--- a/src/zkevm_specs/evm/execution/codecopy.py
+++ b/src/zkevm_specs/evm/execution/codecopy.py
@@ -24,7 +24,7 @@ def codecopy(instruction: Instruction):
     gas_cost = instruction.memory_copier_gas_cost(size, memory_expansion_gas_cost)
 
     if instruction.is_zero(size) == FQ(0):
-        copy_rwc_inc = instruction.copy_lookup(
+        copy_rwc_inc, _ = instruction.copy_lookup(
             instruction.curr.code_hash,
             CopyDataTypeTag.Bytecode,
             instruction.curr.call_id,

--- a/src/zkevm_specs/evm/execution/log.py
+++ b/src/zkevm_specs/evm/execution/log.py
@@ -63,7 +63,7 @@ def log(instruction: Instruction):
             instruction.constrain_bool(FQ(diff))
 
     if instruction.is_zero(msize) == 0 and is_persistent == 1:
-        copy_rwc_inc = instruction.copy_lookup(
+        copy_rwc_inc, _ = instruction.copy_lookup(
             instruction.curr.call_id,
             CopyDataTypeTag.Memory,
             tx_id,

--- a/src/zkevm_specs/evm/execution/return_.py
+++ b/src/zkevm_specs/evm/execution/return_.py
@@ -35,7 +35,7 @@ def return_(instruction: Instruction):
         # callee's memory to bytecode, using the copy circuit.
         code_hash = instruction.curr.aux_data  # Load code_hash witness value from aux_data
         copy_length = return_length
-        copy_rwc_inc = instruction.copy_lookup(
+        copy_rwc_inc, _ = instruction.copy_lookup(
             instruction.curr.call_id,  # src_id
             CopyDataTypeTag.Memory,  # src_type
             code_hash,  # dst_id
@@ -62,7 +62,7 @@ def return_(instruction: Instruction):
             CallContextFieldTag.ReturnDataLength
         )  # rwc += 1
         copy_length = instruction.min(return_length, caller_return_length, N_BYTES_MEMORY_ADDRESS)
-        copy_rwc_inc = instruction.copy_lookup(
+        copy_rwc_inc, _ = instruction.copy_lookup(
             instruction.curr.call_id,  # src_id
             CopyDataTypeTag.Memory,  # src_type
             instruction.next.call_id,  # dst_id

--- a/src/zkevm_specs/evm/execution/sha3.py
+++ b/src/zkevm_specs/evm/execution/sha3.py
@@ -1,6 +1,6 @@
 from ..instruction import Instruction, Transition
 from ..table import CopyDataTypeTag
-from zkevm_specs.util import FQ, GAS_COST_COPY_SHA3, RLC
+from zkevm_specs.util import FQ, GAS_COST_COPY_SHA3
 
 
 def sha3(instruction: Instruction):

--- a/src/zkevm_specs/evm/execution/sha3.py
+++ b/src/zkevm_specs/evm/execution/sha3.py
@@ -1,0 +1,52 @@
+from ..instruction import Instruction, Transition
+from ..table import CopyDataTypeTag
+from zkevm_specs.util import FQ, GAS_COST_COPY_SHA3, RLC
+
+
+def sha3(instruction: Instruction):
+    opcode = instruction.opcode_lookup(True)
+
+    # byte offset in memory.
+    offset = instruction.stack_pop()
+    # byte size to read in memory.
+    size = instruction.stack_pop()
+    # sha3 value pushed to stack.
+    sha3_value = instruction.stack_push()
+
+    # convert RLC encoded stack elements to FQ.
+    memory_offset, length = instruction.memory_offset_and_length(offset, size)
+
+    copy_rwc_inc, rlc_acc = instruction.copy_lookup(
+        instruction.curr.call_id,
+        CopyDataTypeTag.Memory,
+        instruction.curr.call_id,
+        CopyDataTypeTag.RlcAcc,
+        memory_offset,
+        memory_offset + length,
+        FQ.zero(),
+        length,
+        instruction.curr.rw_counter + instruction.rw_counter_offset,
+    )
+    keccak256_rlc_acc = instruction.keccak_lookup(length, rlc_acc)
+
+    instruction.constrain_equal(
+        keccak256_rlc_acc,
+        sha3_value.expr(),
+    )
+
+    # calculate memory expansion gas costs.
+    next_memory_size, memory_expansion_gas_cost = instruction.memory_expansion_dynamic_length(
+        memory_offset, length
+    )
+    gas_cost = instruction.memory_copier_gas_cost(
+        length, memory_expansion_gas_cost, GAS_COST_COPY_SHA3
+    )
+
+    instruction.step_state_transition_in_same_context(
+        opcode,
+        rw_counter=Transition.delta(instruction.rw_counter_offset + copy_rwc_inc),
+        program_counter=Transition.delta(1),
+        stack_pointer=Transition.delta(1),  # 2 stack reads and 1 stack write
+        memory_size=Transition.to(next_memory_size),
+        dynamic_gas_cost=gas_cost,
+    )

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1040,4 +1040,4 @@ class Instruction:
         return copy_table_row.rwc_inc, copy_table_row.value_rlc
 
     def keccak_lookup(self, length: Expression, value_rlc: Expression) -> FQ:
-        return self.tables.keccak_lookup(length, value_rlc).hash_rlc
+        return self.tables.keccak_lookup(length, value_rlc).output

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1037,7 +1037,7 @@ class Instruction:
             rw_counter,
             log_id,
         )
-        return copy_table_row.rwc_inc, copy_table_row.value_rlc
+        return copy_table_row.rwc_inc, copy_table_row.rlc_acc
 
     def keccak_lookup(self, length: Expression, value_rlc: Expression) -> FQ:
         return self.tables.keccak_lookup(length, value_rlc).output

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -999,10 +999,13 @@ class Instruction:
         return cast_expr(next_memory_size, FQ), cast_expr(memory_expansion_gas_cost, FQ)
 
     def memory_copier_gas_cost(
-        self, length: Expression, memory_expansion_gas_cost: Expression
+        self,
+        length: Expression,
+        memory_expansion_gas_cost: Expression,
+        gas_cost_copy: int = GAS_COST_COPY,
     ) -> FQ:
         word_size, _ = self.constant_divmod(length + FQ(31), FQ(32), N_BYTES_MEMORY_SIZE)
-        gas_cost = word_size * GAS_COST_COPY + memory_expansion_gas_cost
+        gas_cost = word_size * gas_cost_copy + memory_expansion_gas_cost
         self.range_check(gas_cost, N_BYTES_GAS)
         return gas_cost
 
@@ -1021,8 +1024,8 @@ class Instruction:
         length: Expression,
         rw_counter: Expression,
         log_id: Expression = None,
-    ) -> FQ:
-        return self.tables.copy_lookup(
+    ) -> Tuple[FQ, FQ]:
+        copy_table_row = self.tables.copy_lookup(
             src_id,
             FQ(src_type),
             dst_id,
@@ -1033,4 +1036,8 @@ class Instruction:
             length,
             rw_counter,
             log_id,
-        ).rwc_inc
+        )
+        return copy_table_row.rwc_inc, copy_table_row.value_rlc
+
+    def keccak_lookup(self, length: Expression, value_rlc: Expression) -> FQ:
+        return self.tables.keccak_lookup(length, value_rlc).hash_rlc

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -419,7 +419,7 @@ class CopyTableRow(TableRow):
     src_addr_end: FQ
     dst_addr: FQ
     length: FQ
-    value_rlc: FQ
+    rlc_acc: FQ
     rw_counter: FQ
     rwc_inc: FQ
 
@@ -485,7 +485,7 @@ class Tables:
                         src_addr_end=first_row.src_addr_end,
                         dst_addr=next_row.addr,
                         length=first_row.bytes_left,
-                        value_rlc=row.rlc_acc,
+                        rlc_acc=row.rlc_acc,
                         rw_counter=first_row.rw_counter,
                         rwc_inc=first_row.rwc_inc_left,
                     )

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -397,6 +397,7 @@ class CopyCircuitRow(TableRow):
     src_addr_end: FQ
     bytes_left: FQ
     value: FQ
+    rlc_acc: FQ
     is_code: FQ
     is_pad: FQ
     rw_counter: FQ
@@ -474,10 +475,6 @@ class Tables:
                 assert i + 1 < len(copy_circuit), "Not enough rows in copy circuit"
                 next_row = copy_circuit[i + 1]
                 assert next_row.q_step == 0, "Invalid copy circuit"
-
-            # update `value_rlc` when we encounter the copy event's last row.
-            if row.is_last == 1:
-                value_rlc = row.value
                 rows.append(
                     CopyTableRow(
                         src_id=first_row.id,
@@ -488,12 +485,11 @@ class Tables:
                         src_addr_end=first_row.src_addr_end,
                         dst_addr=next_row.addr,
                         length=first_row.bytes_left,
-                        value_rlc=value_rlc,
+                        value_rlc=row.rlc_acc,
                         rw_counter=first_row.rw_counter,
                         rwc_inc=first_row.rwc_inc_left,
                     )
                 )
-
         return set(rows)
 
     def fixed_lookup(

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -418,8 +418,16 @@ class CopyTableRow(TableRow):
     src_addr_end: FQ
     dst_addr: FQ
     length: FQ
+    value_rlc: FQ
     rw_counter: FQ
     rwc_inc: FQ
+
+
+@dataclass(frozen=True)
+class KeccakTableRow(TableRow):
+    idx: FQ
+    hash_rlc: FQ
+    value_rlc: FQ
 
 
 class Tables:
@@ -433,6 +441,7 @@ class Tables:
     bytecode_table: Set[BytecodeTableRow]
     rw_table: Set[RWTableRow]
     copy_table: Set[CopyTableRow]
+    keccak_table: Set[KeccakTableRow]
 
     def __init__(
         self,
@@ -441,6 +450,7 @@ class Tables:
         bytecode_table: Set[BytecodeTableRow],
         rw_table: Union[Set[Sequence[Expression]], Set[RWTableRow]],
         copy_circuit: Sequence[CopyCircuitRow] = None,
+        keccak_table: Sequence[KeccakTableRow] = None,
     ) -> None:
         self.block_table = block_table
         self.tx_table = tx_table
@@ -451,29 +461,38 @@ class Tables:
         )
         if copy_circuit is not None:
             self.copy_table = self._convert_copy_circuit_to_table(copy_circuit)
+        if keccak_table is not None:
+            self.keccak_table = set(keccak_table)
 
     def _convert_copy_circuit_to_table(self, copy_circuit: Sequence[CopyCircuitRow]):
-        rows = []
+        rows: List[CopyTableRow] = []
         for i, row in enumerate(copy_circuit):
-            if row.is_first != 1:
-                continue
-            assert i + 1 < len(copy_circuit), "Not enough rows in copy circuit"
-            next_row = copy_circuit[i + 1]
-            assert next_row.q_step == 0, "Invalid copy circuit"
-            rows.append(
-                CopyTableRow(
-                    src_id=row.id,
-                    src_type=row.tag,
-                    dst_id=next_row.id,
-                    dst_type=next_row.tag,
-                    src_addr=row.addr,
-                    src_addr_end=row.src_addr_end,
-                    dst_addr=next_row.addr,
-                    length=row.bytes_left,
-                    rw_counter=row.rw_counter,
-                    rwc_inc=row.rwc_inc_left,
+            # the first row and the row next to it will be used for its fields.
+            if row.is_first == 1:
+                first_row = row
+                assert i + 1 < len(copy_circuit), "Not enough rows in copy circuit"
+                next_row = copy_circuit[i + 1]
+                assert next_row.q_step == 0, "Invalid copy circuit"
+
+            # update `value_rlc` when we encounter the copy event's last row.
+            if row.is_last == 1:
+                value_rlc = row.value
+                rows.append(
+                    CopyTableRow(
+                        src_id=first_row.id,
+                        src_type=first_row.tag,
+                        dst_id=next_row.id,
+                        dst_type=next_row.tag,
+                        src_addr=first_row.addr,
+                        src_addr_end=first_row.src_addr_end,
+                        dst_addr=next_row.addr,
+                        length=first_row.bytes_left,
+                        value_rlc=value_rlc,
+                        rw_counter=first_row.rw_counter,
+                        rwc_inc=first_row.rwc_inc_left,
+                    )
                 )
-            )
+
         return set(rows)
 
     def fixed_lookup(
@@ -580,6 +599,13 @@ class Tables:
             "rw_counter": rw_counter,
         }
         return lookup(CopyTableRow, self.copy_table, query)
+
+    def keccak_lookup(self, length: Expression, value_rlc: Expression):
+        query = {
+            "idx": length - FQ(1),
+            "value_rlc": value_rlc,
+        }
+        return lookup(KeccakTableRow, self.keccak_table, query)
 
 
 T = TypeVar("T", bound=TableRow)

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -425,9 +425,10 @@ class CopyTableRow(TableRow):
 
 @dataclass(frozen=True)
 class KeccakTableRow(TableRow):
-    idx: FQ
-    hash_rlc: FQ
-    value_rlc: FQ
+    state_tag: FQ
+    input_len: FQ
+    acc_input: FQ
+    output: FQ
 
 
 class Tables:
@@ -602,8 +603,9 @@ class Tables:
 
     def keccak_lookup(self, length: Expression, value_rlc: Expression):
         query = {
-            "idx": length - FQ(1),
-            "value_rlc": value_rlc,
+            "state_tag": FQ(2),  # Finalize
+            "input_len": length,
+            "acc_input": value_rlc,
         }
         return lookup(KeccakTableRow, self.keccak_table, query)
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -289,6 +289,15 @@ class CopyDataTypeTag(IntEnum):
     TxCalldata = auto()
     TxLog = auto()
 
+    # RLC Accumulator tag can be used whenever we wish to
+    # accumulates `value` iteratively over all the steps in
+    # copy circuit. This is specifically used in the SHA3
+    # opcode execution where the copy table's last row has
+    # an accumulated value that is the RLC representation of
+    # all input bytes. Using this value, we can then lookup
+    # the Keccak table for the SHA3 of the input bytes.
+    RlcAcc = auto()
+
 
 class WrongQueryKey(Exception):
     def __init__(self, table_name: str, diff: Set[str]) -> None:
@@ -396,6 +405,7 @@ class CopyCircuitRow(TableRow):
     is_bytecode: FQ
     is_tx_calldata: FQ
     is_tx_log: FQ
+    is_rlc_acc: FQ
 
 
 @dataclass(frozen=True)

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -675,7 +675,7 @@ class KeccakCircuit:
 
     def add(self, data: bytes, r: FQ) -> KeccakCircuit:
         rows: List[KeccakTableRow] = []
-        hash_rlc = RLC(keccak256(RLC(bytes(reversed(data)), r, len(data)).le_bytes), r)
+        hash_rlc = RLC(keccak256(data), r, n_bytes=32)
         value_rlc = FQ.zero()
         for i in range(len(data)):
             value_rlc = value_rlc * r + data[i]

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -679,6 +679,7 @@ class CopyCircuit:
 
     def copy(
         self,
+        r: FQ,
         rw_dict: RWDictionary,
         src_id: IntOrFQ,
         src_type: CopyDataTypeTag,
@@ -692,7 +693,7 @@ class CopyCircuit:
         log_id: int = 0,
     ):
         new_rows: List[CopyCircuitRow] = []
-        acc_val = FQ(0)
+        rlc_acc = FQ(0)
         for i in range(int(copy_length)):
             if int(src_addr + i) < int(src_addr_end):
                 is_pad = False
@@ -730,7 +731,7 @@ class CopyCircuit:
 
             # write row
             if dst_type == CopyDataTypeTag.RlcAcc:
-                acc_val += value
+                rlc_acc = rlc_acc * r + value
             self._append_row(
                 new_rows,
                 rw_dict,
@@ -740,7 +741,7 @@ class CopyCircuit:
                 dst_id,
                 dst_type,
                 dst_addr + i,
-                acc_val if dst_type == CopyDataTypeTag.RlcAcc else value,
+                rlc_acc if dst_type == CopyDataTypeTag.RlcAcc else value,
                 is_code,
                 False,
                 log_id=log_id,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -674,19 +674,18 @@ class KeccakCircuit:
         self.rows = []
 
     def add(self, data: bytes, r: FQ) -> KeccakCircuit:
-        rows: List[KeccakTableRow] = []
-        hash_rlc = RLC(keccak256(data), r, n_bytes=32)
-        value_rlc = FQ.zero()
+        output = RLC(keccak256(data), r, n_bytes=32)
+        acc_input = FQ.zero()
         for i in range(len(data)):
-            value_rlc = value_rlc * r + data[i]
-            rows.append(
-                KeccakTableRow(
-                    idx=FQ(i),
-                    hash_rlc=hash_rlc.expr(),
-                    value_rlc=value_rlc,
-                )
+            acc_input = acc_input * r + data[i]
+        self.rows.append(
+            KeccakTableRow(
+                state_tag=FQ(2),  # Finalize
+                input_len=FQ(len(data)),
+                acc_input=acc_input,
+                output=output.expr(),
             )
-        self.rows.extend(rows)
+        )
         return self
 
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -675,14 +675,12 @@ class KeccakCircuit:
 
     def add(self, data: bytes, r: FQ) -> KeccakCircuit:
         output = RLC(keccak256(data), r, n_bytes=32)
-        acc_input = FQ.zero()
-        for i in range(len(data)):
-            acc_input = acc_input * r + data[i]
+        acc_input = RLC(bytes(reversed(data)), r, n_bytes=len(data))
         self.rows.append(
             KeccakTableRow(
                 state_tag=FQ(2),  # Finalize
                 input_len=FQ(len(data)),
-                acc_input=acc_input,
+                acc_input=acc_input.expr(),
                 output=output.expr(),
             )
         )

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -695,7 +695,7 @@ class CopyCircuit:
 
     def __init__(self) -> None:
         self.rows = []
-        self.pad_rows = [CopyCircuitRow(FQ(1), *[FQ(0)] * 17), CopyCircuitRow(*[FQ(0)] * 18)]
+        self.pad_rows = [CopyCircuitRow(FQ(1), *[FQ(0)] * 18), CopyCircuitRow(*[FQ(0)] * 19)]
 
     def table(self) -> Sequence[CopyCircuitRow]:
         return self.rows + self.pad_rows
@@ -716,7 +716,7 @@ class CopyCircuit:
         log_id: int = 0,
     ):
         new_rows: List[CopyCircuitRow] = []
-        rlc_acc = FQ(0)
+        rlc_acc = FQ.zero()
         for i in range(int(copy_length)):
             if int(src_addr + i) < int(src_addr_end):
                 is_pad = False
@@ -746,6 +746,7 @@ class CopyCircuit:
                 src_type,
                 src_addr + i,
                 value,
+                FQ.zero(),  # rlc_acc will be updated later
                 is_code,
                 is_pad,
                 src_addr_end=src_addr_end,
@@ -765,6 +766,7 @@ class CopyCircuit:
                 dst_type,
                 dst_addr + i,
                 rlc_acc if dst_type == CopyDataTypeTag.RlcAcc else value,
+                FQ.zero(),
                 is_code,
                 False,
                 log_id=log_id,
@@ -774,6 +776,8 @@ class CopyCircuit:
         rw_counter = rw_dict.rw_counter
         for row in new_rows:
             row.rwc_inc_left = rw_counter - row.rw_counter
+            if dst_type == CopyDataTypeTag.RlcAcc:
+                row.rlc_acc = rlc_acc
         self.rows.extend(new_rows)
         return self
 
@@ -788,6 +792,7 @@ class CopyCircuit:
         tag: CopyDataTypeTag,
         addr: IntOrFQ,
         value: IntOrFQ,
+        rlc_acc: IntOrFQ,
         is_code: IntOrFQ,
         is_pad: bool,
         src_addr_end: IntOrFQ = FQ(0),
@@ -820,6 +825,7 @@ class CopyCircuit:
                 src_addr_end=FQ(src_addr_end),
                 bytes_left=FQ(bytes_left),
                 value=FQ(value),
+                rlc_acc=FQ(rlc_acc),
                 is_code=FQ(is_code),
                 is_pad=FQ(is_pad),
                 rw_counter=FQ(rw_counter),

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -45,6 +45,7 @@ from .table import (
     CopyDataTypeTag,
     CopyCircuitRow,
     CopyTableRow,
+    KeccakTableRow,
 )
 from .opcode import get_push_size, Opcode
 
@@ -663,6 +664,29 @@ class RWDictionary:
             )
         )
 
+        return self
+
+
+class KeccakCircuit:
+    rows: List[KeccakTableRow]
+
+    def __init__(self) -> None:
+        self.rows = []
+
+    def add(self, data: bytes, r: FQ) -> KeccakCircuit:
+        rows: List[KeccakTableRow] = []
+        hash_rlc = RLC(keccak256(RLC(bytes(reversed(data)), r, len(data)).le_bytes), r)
+        value_rlc = FQ.zero()
+        for i in range(len(data)):
+            value_rlc = value_rlc * r + data[i]
+            rows.append(
+                KeccakTableRow(
+                    idx=FQ(i),
+                    hash_rlc=hash_rlc.expr(),
+                    value_rlc=value_rlc,
+                )
+            )
+        self.rows.extend(rows)
         return self
 
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -672,7 +672,7 @@ class CopyCircuit:
 
     def __init__(self) -> None:
         self.rows = []
-        self.pad_rows = [CopyCircuitRow(FQ(1), *[FQ(0)] * 16), CopyCircuitRow(*[FQ(0)] * 17)]
+        self.pad_rows = [CopyCircuitRow(FQ(1), *[FQ(0)] * 17), CopyCircuitRow(*[FQ(0)] * 18)]
 
     def table(self) -> Sequence[CopyCircuitRow]:
         return self.rows + self.pad_rows
@@ -692,6 +692,7 @@ class CopyCircuit:
         log_id: int = 0,
     ):
         new_rows: List[CopyCircuitRow] = []
+        acc_val = FQ(0)
         for i in range(int(copy_length)):
             if int(src_addr + i) < int(src_addr_end):
                 is_pad = False
@@ -728,6 +729,8 @@ class CopyCircuit:
             )
 
             # write row
+            if dst_type == CopyDataTypeTag.RlcAcc:
+                acc_val += value
             self._append_row(
                 new_rows,
                 rw_dict,
@@ -737,7 +740,7 @@ class CopyCircuit:
                 dst_id,
                 dst_type,
                 dst_addr + i,
-                value,
+                acc_val if dst_type == CopyDataTypeTag.RlcAcc else value,
                 is_code,
                 False,
                 log_id=log_id,
@@ -771,6 +774,7 @@ class CopyCircuit:
         is_bytecode = tag == CopyDataTypeTag.Bytecode
         is_tx_calldata = tag == CopyDataTypeTag.TxCalldata
         is_tx_log = tag == CopyDataTypeTag.TxLog
+        is_rlc_acc = tag == CopyDataTypeTag.RlcAcc
         rw_counter = rw_dict.rw_counter
         if is_memory:
             if is_write:
@@ -800,5 +804,6 @@ class CopyCircuit:
                 is_bytecode=FQ(is_bytecode),
                 is_tx_calldata=FQ(is_tx_calldata),
                 is_tx_log=FQ(is_tx_log),
+                is_rlc_acc=FQ(is_rlc_acc),
             )
         )

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -74,8 +74,6 @@ MAX_REFUND_QUOTIENT_OF_GAS_USED = 5
 MEMORY_EXPANSION_QUAD_DENOMINATOR = 512
 # Coefficient of linear part of memory expansion gas cost
 MEMORY_EXPANSION_LINEAR_COEFF = 3
-# Coefficient of linear part of memory expansion gas cost, specifically in the case of SHA3
-MEMORY_EXPANSION_LINEAR_COEFF_SHA3 = 6
 
 # Maximum number of bytes copied during one single iteration of CopyToMemory, i.e. the internal state used by the
 # CALLDATACOPY gadget

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -41,6 +41,8 @@ GAS_COST_CREATE2 = 32000
 GAS_COST_SELF_DESTRUCT = 5000
 # Gas cost of copying every word
 GAS_COST_COPY = 3
+# Gas cost of copying every word, specifically in the case of SHA3 opcode
+GAS_COST_COPY_SHA3 = 6
 # Gas cost of non-creation transaction
 GAS_COST_TX = 21000
 # Constant gas cost of LOG
@@ -72,6 +74,8 @@ MAX_REFUND_QUOTIENT_OF_GAS_USED = 5
 MEMORY_EXPANSION_QUAD_DENOMINATOR = 512
 # Coefficient of linear part of memory expansion gas cost
 MEMORY_EXPANSION_LINEAR_COEFF = 3
+# Coefficient of linear part of memory expansion gas cost, specifically in the case of SHA3
+MEMORY_EXPANSION_LINEAR_COEFF_SHA3 = 6
 
 # Maximum number of bytes copied during one single iteration of CopyToMemory, i.e. the internal state used by the
 # CALLDATACOPY gadget

--- a/src/zkevm_specs/util/testing.py
+++ b/src/zkevm_specs/util/testing.py
@@ -21,7 +21,6 @@ def div(
 def memory_expansion(
     curr_memory_size: U64,
     address: U64,
-    mem_exp_linear: int = MEMORY_EXPANSION_LINEAR_COEFF,
 ) -> Tuple[U64, U128]:
     # The memory size required for the used address
     address_memory_size = memory_word_size(address)
@@ -35,7 +34,7 @@ def memory_expansion(
 
     # Calculate the gas cost for the memory expansion
     # This gas cost is the difference between the next and current memory costs
-    memory_gas_cost = (next_memory_size - curr_memory_size) * mem_exp_linear + (
+    memory_gas_cost = (next_memory_size - curr_memory_size) * MEMORY_EXPANSION_LINEAR_COEFF + (
         next_quad_memory_cost - curr_quad_memory_cost
     )
 

--- a/src/zkevm_specs/util/testing.py
+++ b/src/zkevm_specs/util/testing.py
@@ -21,6 +21,7 @@ def div(
 def memory_expansion(
     curr_memory_size: U64,
     address: U64,
+    mem_exp_linear: int = MEMORY_EXPANSION_LINEAR_COEFF,
 ) -> Tuple[U64, U128]:
     # The memory size required for the used address
     address_memory_size = memory_word_size(address)
@@ -34,7 +35,7 @@ def memory_expansion(
 
     # Calculate the gas cost for the memory expansion
     # This gas cost is the difference between the next and current memory costs
-    memory_gas_cost = (next_memory_size - curr_memory_size) * MEMORY_EXPANSION_LINEAR_COEFF + (
+    memory_gas_cost = (next_memory_size - curr_memory_size) * mem_exp_linear + (
         next_quad_memory_cost - curr_quad_memory_cost
     )
 

--- a/tests/evm/test_calldatacopy.py
+++ b/tests/evm/test_calldatacopy.py
@@ -139,6 +139,7 @@ def test_calldatacopy(
         ]
     )
     copy_circuit = CopyCircuit().copy(
+        randomness,
         rw_dictionary,
         TX_ID if from_tx else CALLER_ID,
         CopyDataTypeTag.TxCalldata if from_tx else CopyDataTypeTag.Memory,
@@ -174,7 +175,7 @@ def test_calldatacopy(
         copy_circuit=copy_circuit.rows,
     )
 
-    verify_copy_table(copy_circuit, tables)
+    verify_copy_table(copy_circuit, tables, randomness)
     verify_steps(
         randomness=randomness,
         tables=tables,

--- a/tests/evm/test_calldatacopy.py
+++ b/tests/evm/test_calldatacopy.py
@@ -109,13 +109,6 @@ def test_calldatacopy(
         .stack_read(CALL_ID, 1021, memory_offset_rlc)
         .stack_read(CALL_ID, 1022, data_offset_rlc)
         .stack_read(CALL_ID, 1023, length_rlc)
-        .call_context_read(CALL_ID, CallContextFieldTag.TxId, TX_ID)
-    )
-    rw_dictionary = (
-        RWDictionary(1)
-        .stack_read(CALL_ID, 1021, memory_offset_rlc)
-        .stack_read(CALL_ID, 1022, data_offset_rlc)
-        .stack_read(CALL_ID, 1023, length_rlc)
     )
     if from_tx:
         rw_dictionary.call_context_read(CALL_ID, CallContextFieldTag.TxId, TX_ID).call_context_read(

--- a/tests/evm/test_codecopy.py
+++ b/tests/evm/test_codecopy.py
@@ -136,6 +136,7 @@ def test_codecopy(src_addr: U64, dst_addr: U64, length: U64):
 
     src_data = dict([(i, (code.code[i], code.is_code[i])) for i in range(len(code.code))])
     copy_circuit = CopyCircuit().copy(
+        randomness,
         rw_dictionary,
         code_hash.rlc_value,
         CopyDataTypeTag.Bytecode,
@@ -174,7 +175,7 @@ def test_codecopy(src_addr: U64, dst_addr: U64, length: U64):
         copy_circuit=copy_circuit.rows,
     )
 
-    verify_copy_table(copy_circuit, tables)
+    verify_copy_table(copy_circuit, tables, randomness)
 
     verify_steps(
         randomness=randomness,

--- a/tests/evm/test_logs.py
+++ b/tests/evm/test_logs.py
@@ -147,6 +147,7 @@ def make_log(
     src_data = dict([(mstart + i, byte) for (i, byte) in enumerate(data)])
     if is_persistent:
         copy_circuit.copy(
+            randomness,
             rw_dictionary,
             CALL_ID,
             CopyDataTypeTag.Memory,
@@ -221,7 +222,7 @@ def test_single_log(topics: list, mstart: U64, msize: U64, is_persistent: bool):
         rw_table=set(rw_dictionary.rws),
         copy_circuit=copy_circuit.rows,
     )
-    verify_copy_table(copy_circuit, tables)
+    verify_copy_table(copy_circuit, tables, randomness)
     verify_steps(
         randomness=randomness,
         tables=tables,
@@ -303,7 +304,7 @@ def test_multi_logs(log_entries):
         copy_circuit=copy_circuit.rows,
     )
 
-    verify_copy_table(copy_circuit, tables)
+    verify_copy_table(copy_circuit, tables, randomness)
     verify_steps(
         randomness=randomness,
         tables=tables,

--- a/tests/evm/test_return.py
+++ b/tests/evm/test_return.py
@@ -163,6 +163,7 @@ def test_return_not_root_not_create(
     src_data = dict([(i, CALLEE_MEMORY[i] if i < len(CALLEE_MEMORY) else 0) for i in range(return_offset, return_offset + return_length)])
     copy_length = min(return_length, caller_return_length)
     copy_circuit = CopyCircuit().copy(
+        randomness,
         rw_dict,
         callee_id,
         CopyDataTypeTag.Memory,
@@ -205,7 +206,7 @@ def test_return_not_root_not_create(
         copy_circuit=copy_circuit.rows,
     )
 
-    verify_copy_table(copy_circuit, tables)
+    verify_copy_table(copy_circuit, tables, randomness)
 
     verify_steps(
         randomness=randomness,

--- a/tests/evm/test_sha3.py
+++ b/tests/evm/test_sha3.py
@@ -58,11 +58,7 @@ def test_sha3(offset: U64, length: U64):
     bytecode_hash = RLC(bytecode.hash(), randomness)
 
     pc = len(memory_chunks) * 67 + 66
-    memory_sha3 = keccak256(
-        RLC(
-            bytes(reversed(memory_snapshot[offset : offset + length])), randomness, n_bytes=length
-        ).le_bytes
-    )
+    memory_sha3 = keccak256(memory_snapshot[offset : offset + length])
     memory_sha3_rlc = RLC(memory_sha3, randomness, n_bytes=32)
     next_memory_size, memory_expansion_cost = memory_expansion(
         offset + length, offset + length, MEMORY_EXPANSION_LINEAR_COEFF_SHA3

--- a/tests/evm/test_sha3.py
+++ b/tests/evm/test_sha3.py
@@ -1,0 +1,143 @@
+import pytest
+
+from zkevm_specs.evm import (
+    Block,
+    Bytecode,
+    CopyCircuit,
+    CopyDataTypeTag,
+    ExecutionState,
+    KeccakCircuit,
+    Opcode,
+    RWDictionary,
+    StepState,
+    Tables,
+    verify_steps,
+)
+from zkevm_specs.copy_circuit import verify_copy_table
+from zkevm_specs.util import (
+    keccak256,
+    memory_expansion,
+    memory_word_size,
+    rand_bytes,
+    rand_fq,
+    FQ,
+    GAS_COST_COPY_SHA3,
+    MEMORY_EXPANSION_LINEAR_COEFF_SHA3,
+    RLC,
+    U64,
+)
+
+
+CALL_ID = 1
+TESTING_DATA = ((0x20, 0x40),)
+
+
+@pytest.mark.parametrize("offset, length", TESTING_DATA)
+def test_sha3(offset: U64, length: U64):
+    randomness = rand_fq()
+
+    offset_rlc = RLC(offset, randomness)
+    length_rlc = RLC(length, randomness)
+
+    # divide rand memory into chunks of 32 which we will push and mstore.
+    memory_snapshot = rand_bytes(offset + length)
+    memory_chunks = list()
+    for i in range(0, len(memory_snapshot), 32):
+        memory_chunks.append(memory_snapshot[i : i + 32])
+    src_data = dict(
+        [
+            (i, memory_snapshot[i] if i < len(memory_snapshot) else 0)
+            for i in range(offset, offset + length)
+        ]
+    )
+
+    bytecode = Bytecode()
+    for i, chunk in enumerate(memory_chunks):
+        bytecode.push(32 * i, n_bytes=32).push(chunk, n_bytes=32).mstore()
+    bytecode.push(offset_rlc, n_bytes=32).push(length_rlc, n_bytes=32).sha3().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
+
+    pc = len(memory_chunks) * 67 + 66
+    memory_sha3 = keccak256(
+        RLC(
+            bytes(reversed(memory_snapshot[offset : offset + length])), randomness, n_bytes=length
+        ).le_bytes
+    )
+    memory_sha3_rlc = RLC(memory_sha3, randomness, n_bytes=32)
+    next_memory_size, memory_expansion_cost = memory_expansion(
+        offset + length, offset + length, MEMORY_EXPANSION_LINEAR_COEFF_SHA3
+    )
+    gas = (
+        Opcode.SHA3.constant_gas_cost()
+        + memory_expansion_cost
+        + memory_word_size(length) * GAS_COST_COPY_SHA3
+    )
+
+    rw_dictionary = (
+        RWDictionary(1)
+        .stack_write(CALL_ID, 1023, length_rlc)
+        .stack_write(CALL_ID, 1022, offset_rlc)
+        .stack_read(CALL_ID, 1022, offset_rlc)
+        .stack_read(CALL_ID, 1023, length_rlc)
+        .stack_write(CALL_ID, 1023, memory_sha3_rlc)
+    )
+    rw_counter_interim = rw_dictionary.rw_counter
+
+    copy_circuit = CopyCircuit().copy(
+        randomness,
+        rw_dictionary,
+        CALL_ID,
+        CopyDataTypeTag.Memory,
+        CALL_ID,
+        CopyDataTypeTag.RlcAcc,
+        offset,
+        offset + length,
+        FQ.zero(),
+        length,
+        src_data,
+    )
+    assert rw_dictionary.rw_counter - rw_counter_interim == length
+
+    keccak_circuit = KeccakCircuit().add(memory_snapshot[offset : offset + length], randomness)
+
+    tables = Tables(
+        block_table=set(Block().table_assignments(randomness)),
+        tx_table=set(),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
+        rw_table=set(rw_dictionary.rws),
+        copy_circuit=copy_circuit.rows,
+        keccak_table=keccak_circuit.rows,
+    )
+
+    verify_copy_table(copy_circuit, tables, randomness)
+
+    verify_steps(
+        randomness=randomness,
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.SHA3,
+                rw_counter=3,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=pc,
+                stack_pointer=1022,
+                memory_size=next_memory_size,
+                gas_left=gas,
+            ),
+            StepState(
+                execution_state=ExecutionState.STOP,
+                rw_counter=rw_dictionary.rw_counter,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=pc + 1,
+                stack_pointer=1023,
+                memory_size=next_memory_size,
+                gas_left=0,
+            ),
+        ],
+    )

--- a/tests/evm/test_sha3.py
+++ b/tests/evm/test_sha3.py
@@ -36,9 +36,6 @@ TESTING_DATA = ((0x20, 0x40),)
 def test_sha3(offset: U64, length: U64):
     randomness = rand_fq()
 
-    offset_rlc = RLC(offset, randomness)
-    length_rlc = RLC(length, randomness)
-
     # divide rand memory into chunks of 32 which we will push and mstore.
     memory_snapshot = rand_bytes(offset + length)
     memory_chunks = list()
@@ -54,7 +51,7 @@ def test_sha3(offset: U64, length: U64):
     bytecode = Bytecode()
     for i, chunk in enumerate(memory_chunks):
         bytecode.push(32 * i, n_bytes=32).push(chunk, n_bytes=32).mstore()
-    bytecode.push(offset_rlc, n_bytes=32).push(length_rlc, n_bytes=32).sha3().stop()
+    bytecode.push(offset, n_bytes=32).push(length, n_bytes=32).sha3().stop()
     bytecode_hash = RLC(bytecode.hash(), randomness)
 
     pc = len(memory_chunks) * 67 + 66
@@ -68,6 +65,9 @@ def test_sha3(offset: U64, length: U64):
         + memory_expansion_cost
         + memory_word_size(length) * GAS_COST_COPY_SHA3
     )
+
+    offset_rlc = RLC(offset, randomness)
+    length_rlc = RLC(length, randomness)
 
     rw_dictionary = (
         RWDictionary(1)

--- a/tests/evm/test_sha3.py
+++ b/tests/evm/test_sha3.py
@@ -22,7 +22,6 @@ from zkevm_specs.util import (
     rand_fq,
     FQ,
     GAS_COST_COPY_SHA3,
-    MEMORY_EXPANSION_LINEAR_COEFF_SHA3,
     RLC,
     U64,
 )
@@ -57,9 +56,7 @@ def test_sha3(offset: U64, length: U64):
     pc = len(memory_chunks) * 67 + 66
     memory_sha3 = keccak256(memory_snapshot[offset : offset + length])
     memory_sha3_rlc = RLC(memory_sha3, randomness, n_bytes=32)
-    next_memory_size, memory_expansion_cost = memory_expansion(
-        offset + length, offset + length, MEMORY_EXPANSION_LINEAR_COEFF_SHA3
-    )
+    next_memory_size, memory_expansion_cost = memory_expansion(offset + length, offset + length)
     gas = (
         Opcode.SHA3.constant_gas_cost()
         + memory_expansion_cost


### PR DESCRIPTION
This PR adds a `RlcAcc` type in the `CopyDataTypeTag` enum.

This tag is reserved for copy destination where instead of copying byte to byte (read to write), we're accumulating an RLC value in the destination. That is:
```
write_val::cur == (write_val::prev * r) + read_val::cur
```

This variant of the copy circuit will be used for `SHA3` opcode execution gadget, where the goal is to find a final accumulator value over each byte from the input. The final RLC accumulator will be used to lookup to the Keccak table and find the `SHA3` of the input bytes.

The PR also implements the `SHA3` opcode.

Closes #228 
Closes #223 