### PR TITLE
Unify RLC functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ type: ## Check the typing of the Python code
 	mypy src
 
 test: ## Run tests
-	pytest
+	pytest --doctest-modules
 
 
 .PHONY: help install fmt lint test

--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
-from typing import Tuple, List, Sequence
-from functools import reduce
+from typing import Tuple, List
 
-from .util import FQ, U64, U160, U256
 from .util import (
+    FQ,
+    U64,
+    U160,
+    U256,
+    linear_combine,
     PUBLIC_INPUTS_BLOCK_LEN as BLOCK_LEN,
     PUBLIC_INPUTS_EXTRA_LEN as EXTRA_LEN,
     PUBLIC_INPUTS_TX_LEN as TX_LEN,
@@ -284,13 +287,6 @@ class PublicData:
         )
 
 
-def linear_combine(seq: Sequence[FQ], base: FQ) -> FQ:
-    def accumulate(acc: FQ, v: FQ) -> FQ:
-        return acc * base + FQ(v)
-
-    return reduce(accumulate, reversed(seq), FQ(0))
-
-
 def public_data2witness(
     public_data: PublicData, MAX_TXS: int, MAX_CALLDATA_BYTES: int, rand_rpi: FQ
 ) -> Witness:
@@ -316,7 +312,7 @@ def public_data2witness(
     assert len(raw_public_inputs) == BLOCK_LEN + EXTRA_LEN + 3 * (
         TX_LEN * MAX_TXS + MAX_CALLDATA_BYTES
     )
-    rpi_rlc = linear_combine(raw_public_inputs, rand_rpi)
+    rpi_rlc = linear_combine(raw_public_inputs, rand_rpi, range_check=False)
     # NOTE: End rlc calculation of raw_public_inputs.
 
     rpi_rlc_acc_col = [raw_public_inputs[-1]]

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -1,8 +1,8 @@
-from typing import NamedTuple, Tuple, List, Sequence, Set, Union, cast
+from typing import NamedTuple, Tuple, List, Set, Union, cast
 from enum import IntEnum
 from math import log, ceil
 
-from .util import FQ, RLC, U160, U256, Expression
+from .util import FQ, RLC, U160, U256, Expression, linear_combine
 from .encoding import U8, is_circuit_code
 from .evm import (
     RW,
@@ -149,13 +149,6 @@ class Tables:
             "value_prev": value_prev,
         }
         return lookup(MPTTableRow, self.mpt_table, query)
-
-
-def linear_combine(limbs: Sequence[FQ], base: FQ) -> FQ:
-    ret = FQ.zero()
-    for limb in reversed(limbs):
-        ret = ret * base + limb
-    return ret
 
 
 # Boolean Expression builder
@@ -427,11 +420,9 @@ def check_state_row(row: Row, row_prev: Row, tables: Tables, randomness: FQ):
     # 0.1. address is linear combination of 10 x 16bit limbs and also in range
     for limb in row.address_limbs():
         assert_in_range(limb, 0, 2**16 - 1)
-    assert row.address() == linear_combine(row.address_limbs(), FQ(2**16))
+    assert row.address() == linear_combine(row.address_limbs(), FQ(2**16), range_check=False)
 
     # 0.2. address is RLC encoded
-    for limb in row.storage_key_bytes():
-        assert_in_range(limb, 0, 2**8 - 1)
     assert row.storage_key() == linear_combine(row.storage_key_bytes(), randomness)
 
     # 0.3. is_write is boolean

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -1,6 +1,6 @@
 from .encoding import is_circuit_code
 from typing import NamedTuple, Tuple, List, Set
-from .util import FQ, RLC, U160, U256, U64
+from .util import FQ, RLC, U160, U256, U64, linear_combine
 from enum import IntEnum
 from eth_keys import KeyAPI  # type: ignore
 import rlp  # type: ignore
@@ -236,14 +236,14 @@ class SignVerifyChip:
         )
 
         # 2. Verify that the first 20 bytes of the pub_key_hash equal the address
-        addr_expr = FQ.linear_combine(list(reversed(self.pub_key_hash.le_bytes[-20:])), FQ(2**8))
+        addr_expr = linear_combine(list(reversed(self.pub_key_hash.le_bytes[-20:])), FQ(2**8))
         assert (
             addr_expr == self.address
         ), f"{assert_msg}: {hex(addr_expr.n)} != {hex(self.address.n)}"
 
         # 3. Verify that the signed message in the ecdsa_chip with RLC encoding
         # corresponds to msg_hash_rlc
-        msg_hash_rlc_expr = is_not_padding * FQ.linear_combine(self.msg_hash_bytes, randomness)
+        msg_hash_rlc_expr = is_not_padding * linear_combine(self.msg_hash_bytes, randomness)
         assert (
             msg_hash_rlc_expr == self.msg_hash_rlc
         ), f"{assert_msg}: {hex(msg_hash_rlc_expr.n)} != {hex(self.msg_hash_rlc.n)}"

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -4,19 +4,17 @@ from py_ecc import bn128
 from py_ecc.utils import prime_field_inv
 
 
-def linear_combine(le_bytes: Sequence[Union[int, FQ]], base: FQ, range_check: bool = True) -> FQ:
+def linear_combine(seq: Sequence[Union[int, FQ]], base: FQ, range_check: bool = True) -> FQ:
     """
-    Aggregate bytes into a single field element.
-    If we intend to use it as a commitment, the base must be a secured random number.
-    >>> r = 10
-    >>> assert linear_combine([1, 2, 3], r) == 1 * r**2 + 2 * r + 3
+    Aggregate a sequence of data into a single field element.
+    To use it as a commitment, the base must be a secured random number.
     If the input represents a sequence of data, apply the function directly.
     If the input represents a number, it must be in little-endian order.
-    Do not use linear_combine(le_limbs, 256) to evaluate the integer value.
+    >>> r = 10
+    >>> assert linear_combine([1, 2, 3], r) == 1 + 2 * r + 3 * r**2
     """
     result = FQ.zero()
-    be_bytes = reversed(le_bytes)
-    for limb in be_bytes:
+    for limb in reversed(seq):
         if range_check:
             limb_int = limb.n if isinstance(limb, FQ) else limb
             assert 0 <= limb_int < 256, "Each byte should fit in 8-bit"


### PR DESCRIPTION
We defined duplicated `linear_combine` functions throughout the codebase.

We define a common `linear_combine` to make sure all circuits behave in the same way.