### PR TITLE
Update EndBlock spec; update tx_table

### DIFF
--- a/specs/tables.md
+++ b/specs/tables.md
@@ -14,14 +14,18 @@ Proved by the tx circuit.
 | $TxID  | Nonce               | 0          | $value  |
 | $TxID  | Gas                 | 0          | $value  |
 | $TxID  | GasPrice            | 0          | $value  |
-| $TxID  | GasTipCap           | 0          | $value  |
-| $TxID  | GasFeeCap           | 0          | $value  |
 | $TxID  | CallerAddress       | 0          | $value  |
 | $TxID  | CalleeAddress       | 0          | $value  |
 | $TxID  | IsCreate            | 0          | $value  |
 | $TxID  | Value               | 0          | $value  |
 | $TxID  | CallDataLength      | 0          | $value  |
+| $TxID  | CallDataGasCost     | 0          | $value  |
+| $TxID  | TxSignHash          | 0          | $value  |
 | $TxID  | CallData            | $ByteIndex | $value  |
+| $TxID  | Pad                 | 0          | $value  |
+
+NOTE: `CallDataGasCost` and `TxSignHash` are values calculated by the verifier
+and used to reduce the circuit complexity.  They may be removed in the future.
 
 ## `rw_table`
 

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -2,9 +2,15 @@ from ...util import FQ
 from ..instruction import Instruction, Transition
 from ..table import CallContextFieldTag
 
+# EndBlock is an execution state that constraints the following:
+# 1. Once the EndBlock state is reached, there's no other execution states appearing until the end of the EVM Circuit.  In particular, after the first EndBlock, there will be no more lookups to the rw_table.
+# 2. The number of meaningful entries (non-padding) in the rw_table match the rw_counter after the EndBlock state is processed.
+#   - instruction.curr.rw_counter
+# 3. The number of txs processed by the EVM Circuit match the number of txs in the TxTable
+#    total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
 
-# TODO: Introduce constrain_instance to constrain the equality between witness
-#       and public input, for total_tx and total_rw
+# Extra
+# 4. We need to prove that the EndBlock state exists
 
 
 def end_block(instruction: Instruction):
@@ -23,9 +29,21 @@ def end_block(instruction: Instruction):
             total_rw,
             FQ(len(instruction.tables.rw_table)),
         )
+
+        # TODO: lookup to rw_table to verify rw_counter
     else:
         # Propagate rw_counter and call_id all the way down
         instruction.constrain_step_state_transition(
             rw_counter=Transition.same(),
             call_id=Transition.same(),
         )
+
+    rw_table_size = len(instruction.tables.rw_table)
+    total_rw = instruction.curr.rw_counter + 1  # extra 1 from the tx_id lookup
+    # Verify that there are at most total_rw meaningful entries in the rw_table
+    instruction.rw_table_start_lookup(1)
+    instruction.rw_table_start_lookup(rw_table_size - total_rw)
+    # Since every lookup done in the EVM circuit must succeed and uses a unique
+    # rw_counter, we know that at least there are total_rw meaningful entries
+    # in the rw_table.
+    # We conclude that the number of meaningful entries in the rw_table is total_rw.

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -33,10 +33,13 @@ def get_tx_table_max_txs(table: Set[TxTableRow]) -> int:
     fixed_field_count = 0
     for row in table:
         print(vars(row))
-        if (row.field_tag != TxContextFieldTag.CallData) or (row.field_tag == TxContextFieldTag.Pad and row.tx_id != 0):
+        if (row.field_tag != TxContextFieldTag.CallData) or (
+            row.field_tag == TxContextFieldTag.Pad and row.tx_id != 0
+        ):
             fixed_field_count += 1
-    print(f'fixed_field_count = {fixed_field_count}')
+    print(f"fixed_field_count = {fixed_field_count}")
     return fixed_field_count // TxContextFieldTag.TxSignHash
+
 
 def end_block(instruction: Instruction):
     if instruction.is_last_step:
@@ -58,7 +61,10 @@ def end_block(instruction: Instruction):
         total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
         # Verify that there are at most total_txs meaningful entries in the tx_table
         instruction.tx_context_lookup(FQ(1), TxContextFieldTag.Pad)
-        instruction.tx_context_lookup(FQ((tx_table_max_txs - total_tx.expr().n) * TxContextFieldTag.TxSignHash), TxContextFieldTag.Pad)
+        instruction.tx_context_lookup(
+            FQ((tx_table_max_txs - total_tx.expr().n) * TxContextFieldTag.TxSignHash),
+            TxContextFieldTag.Pad,
+        )
         # Since every tx lookup done in the EVM circuit must succeed and uses a unique
         # tx_id, we know that at least there are total_tx meaningful txs
         # in the tx_table.
@@ -69,4 +75,3 @@ def end_block(instruction: Instruction):
             rw_counter=Transition.same(),
             call_id=Transition.same(),
         )
-

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -1,36 +1,68 @@
 from ...util import FQ
 from ..instruction import Instruction, Transition
-from ..table import CallContextFieldTag
+from ..table import CallContextFieldTag, TxTableRow, TxContextFieldTag
+from typing import Set
 
 # EndBlock is an execution state that constraints the following:
-# 1. Once the EndBlock state is reached, there's no other execution states appearing until the end of the EVM Circuit.  In particular, after the first EndBlock, there will be no more lookups to the rw_table.
+# 1. Once the EndBlock state is reached, there's no other execution states appearing until the end of the EVM Circuit.  In particular, after the first EndBlock, there will be no new lookups to the rw_table.
 # 2. The number of meaningful entries (non-padding) in the rw_table match the rw_counter after the EndBlock state is processed.
-#   - instruction.curr.rw_counter
 # 3. The number of txs processed by the EVM Circuit match the number of txs in the TxTable
 #    total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
 
-# Extra
+# As an extra point:
 # 4. We need to prove that the EndBlock state exists
 
+# We prove (1) by constraining the transition rule that after an EndBlock
+# state, only an EndBlockState can follow.
+#
+# We prove (2) and (3) by proving that at least `MAX_COUNT - evm_circuit_count`
+# padding elements exist in the rw table and tx table.  To achieve this, we do
+# padding at the beginning of both tables with sequential indexes at
+# `rw_counter` (in rw_table) or `tx_id` (in tx_table).
+#
+# We prove (4) in the circuit implementation by constraining that the last
+# execution step at the end of the EVM circuit is an EndBlock.  When the number
+# of steps is less than the EVM circuit height, we pad at the end with
+# EndBlock.  This will require the EndBlock to have height = 1 in the circuit,
+# which can be achieved after reducing the number of cells used in the state
+# selector.
+
+# Count the max number of txs that the TxTable can hold by counting rows of
+# fixed fields + padding rows in the fixed fields section.
+def get_tx_table_max_txs(table: Set[TxTableRow]) -> int:
+    fixed_field_count = 0
+    for row in table:
+        print(vars(row))
+        if (row.field_tag != TxContextFieldTag.CallData) or (row.field_tag == TxContextFieldTag.Pad and row.tx_id != 0):
+            fixed_field_count += 1
+    print(f'fixed_field_count = {fixed_field_count}')
+    return fixed_field_count // TxContextFieldTag.TxSignHash
 
 def end_block(instruction: Instruction):
     if instruction.is_last_step:
-        # Verify final step has tx_id identical to the tx amount in tx_table.
-        total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
-        instruction.constrain_equal(
-            total_tx,
-            FQ(max([row.tx_id.expr().n for row in instruction.tables.tx_table])),
-        )
-
-        # Verify rw_counter counts to identical rw amount in rw_table to ensure
-        # there is no malicious insertion.
+        # 1. Verify rw_counter counts to the same number of meaningful rows in
+        # rw_table to ensure there is no malicious insertion.
+        rw_table_size = len(instruction.tables.rw_table)
         total_rw = instruction.curr.rw_counter + 1  # extra 1 from the tx_id lookup
-        instruction.constrain_equal(
-            total_rw,
-            FQ(len(instruction.tables.rw_table)),
-        )
+        # Verify that there are at most total_rw meaningful entries in the rw_table
+        instruction.rw_table_start_lookup(FQ(1))
+        instruction.rw_table_start_lookup(rw_table_size - total_rw)
+        # Since every lookup done in the EVM circuit must succeed and uses a unique
+        # rw_counter, we know that at least there are total_rw meaningful entries
+        # in the rw_table.
+        # We conclude that the number of meaningful entries in the rw_table is total_rw.
 
-        # TODO: lookup to rw_table to verify rw_counter
+        # 2. Verify that final step as tx_id identical to the number of txs in
+        # tx_table.
+        tx_table_max_txs = get_tx_table_max_txs(instruction.tables.tx_table)
+        total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
+        # Verify that there are at most total_txs meaningful entries in the tx_table
+        instruction.tx_context_lookup(FQ(1), TxContextFieldTag.Pad)
+        instruction.tx_context_lookup(FQ((tx_table_max_txs - total_tx.expr().n) * TxContextFieldTag.TxSignHash), TxContextFieldTag.Pad)
+        # Since every tx lookup done in the EVM circuit must succeed and uses a unique
+        # tx_id, we know that at least there are total_tx meaningful txs
+        # in the tx_table.
+        # We conclude that the number of meaningful txs in the tx_table is total_tx.
     else:
         # Propagate rw_counter and call_id all the way down
         instruction.constrain_step_state_transition(
@@ -38,12 +70,3 @@ def end_block(instruction: Instruction):
             call_id=Transition.same(),
         )
 
-    rw_table_size = len(instruction.tables.rw_table)
-    total_rw = instruction.curr.rw_counter + 1  # extra 1 from the tx_id lookup
-    # Verify that there are at most total_rw meaningful entries in the rw_table
-    instruction.rw_table_start_lookup(1)
-    instruction.rw_table_start_lookup(rw_table_size - total_rw)
-    # Since every lookup done in the EVM circuit must succeed and uses a unique
-    # rw_counter, we know that at least there are total_rw meaningful entries
-    # in the rw_table.
-    # We conclude that the number of meaningful entries in the rw_table is total_rw.

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -13,7 +13,7 @@ from typing import Set
 # 4. We need to prove that the EndBlock state exists
 
 # We prove (1) by constraining the transition rule that after an EndBlock
-# state, only an EndBlockState can follow.
+# state, only an EndBlock state can follow.
 #
 # We prove (2) and (3) by proving that at least `MAX_COUNT - evm_circuit_count`
 # padding elements exist in the rw table and tx table.  To achieve this, we do
@@ -32,12 +32,10 @@ from typing import Set
 def get_tx_table_max_txs(table: Set[TxTableRow]) -> int:
     fixed_field_count = 0
     for row in table:
-        print(vars(row))
         if (row.field_tag != TxContextFieldTag.CallData) or (
             row.field_tag == TxContextFieldTag.Pad and row.tx_id != 0
         ):
             fixed_field_count += 1
-    print(f"fixed_field_count = {fixed_field_count}")
     return fixed_field_count // TxContextFieldTag.TxSignHash
 
 

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -752,6 +752,10 @@ class Instruction:
             call_id = self.curr.call_id
         return self.rw_lookup(rw, RWTableTag.CallContext, call_id, FQ(field_tag)).value
 
+    def rw_table_start_lookup(self, counter: Expression):
+        # Raises exception if no lookup matches
+        self.rw_lookup(rw=RW.Read, tag=RWTableTag.Start, rw_counter=counter)
+
     def reversion_info(self, call_id: Expression = None) -> ReversionInfo:
         [rw_counter_end_of_reversion, is_persistent] = [
             self.call_context_lookup(tag, call_id=call_id)

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -365,6 +365,7 @@ class BytecodeTableRow(TableRow):
     is_code: Expression
     value: Expression
 
+
 @dataclass(frozen=True)
 class RWTableRow(TableRow):
     rw_counter: Expression

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -165,6 +165,8 @@ class RWTableTag(IntEnum):
     will be verified to be consistent between each write.
     """
 
+    Start = auto()  # Used for upper rows padding
+
     TxAccessListAccount = auto()
     TxAccessListAccountStorage = auto()
     TxRefund = auto()
@@ -360,7 +362,6 @@ class BytecodeTableRow(TableRow):
     index: Expression
     is_code: Expression
     value: Expression
-
 
 @dataclass(frozen=True)
 class RWTableRow(TableRow):

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -130,7 +130,9 @@ class TxContextFieldTag(IntEnum):
     Value = auto()
     CallDataLength = auto()
     CallDataGasCost = auto()
+    TxSignHash = auto()
     CallData = auto()
+    Pad = auto()
 
 
 class BytecodeFieldTag(IntEnum):

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -202,6 +202,12 @@ class Transaction:
                     FQ(0),
                     FQ(self.call_data_gas_cost()),
                 ),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.TxSignHash),
+                    FQ(0),
+                    FQ(1234),  # Mock value for TxSignHash
+                ),
             ],
             map(
                 lambda item: TxTableRow(

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -404,7 +404,10 @@ def txs2witness(
     # number padding rows in the fixed region.   And fill all the rows in the
     # dynamic region to reach MAX_CALLDATA_BYTES with pad rows in the back.
     rows = (
-        [Row(FQ(i + 1), FQ(Tag.Pad), FQ(0), FQ(0)) for i in range((MAX_TXS - len(txs)) * Tag.TxSignHash)]
+        [
+            Row(FQ(i + 1), FQ(Tag.Pad), FQ(0), FQ(0))
+            for i in range((MAX_TXS - len(txs)) * Tag.TxSignHash)
+        ]
         + tx_fixed_rows
         + tx_dyn_rows
         + [Row(FQ(0), FQ(Tag.Pad), FQ(0), FQ(0))] * (MAX_CALLDATA_BYTES - len(tx_dyn_rows))

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -10,30 +10,10 @@ from .util import (
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
 )
-from enum import IntEnum
 from eth_keys import KeyAPI  # type: ignore
 import rlp  # type: ignore
 from eth_utils import keccak
-
-
-class Tag(IntEnum):
-    """
-    Tag used as second key in the Tx Circuit Rows to "select" the transaction field target.
-    Can be encoded in 4 bits.
-    """
-
-    Nonce = 1
-    Gas = 2
-    GasPrice = 3
-    CallerAddress = 4
-    CalleeAddress = 5
-    IsCreate = 6
-    Value = 7
-    CallDataLength = 8
-    CallDataGasCost = 9
-    TxSignHash = 10
-    CallData = 11
-    Pad = 12
+from .evm import TxContextFieldTag as Tag
 
 
 class Row:

--- a/tests/evm/test_end_block.py
+++ b/tests/evm/test_end_block.py
@@ -24,6 +24,7 @@ MAX_CALLDATA_BYTES = 0
 
 MAX_RWS = 64
 
+
 @pytest.mark.parametrize("is_last_step", TESTING_DATA)
 def test_end_block(is_last_step: bool):
     randomness = rand_fq()
@@ -33,11 +34,25 @@ def test_end_block(is_last_step: bool):
     # dummy read/write for counting
     rw_rows = [RWTableRow(FQ(i), *9 * [FQ(0)]) for i in range(22)]
     if is_last_step:
-        rw_rows.append(RWTableRow(FQ(22), FQ(RW.Read), FQ(RWTableTag.CallContext), FQ(1), FQ(CallContextFieldTag.TxId), value=FQ(tx.id)))
-    rw_padding = [RWTableRow(FQ(i+1), FQ(0), FQ(RWTableTag.Start)) for i in range(MAX_RWS - len(rw_rows))]
+        rw_rows.append(
+            RWTableRow(
+                FQ(22),
+                FQ(RW.Read),
+                FQ(RWTableTag.CallContext),
+                FQ(1),
+                FQ(CallContextFieldTag.TxId),
+                value=FQ(tx.id),
+            )
+        )
+    rw_padding = [
+        RWTableRow(FQ(i + 1), FQ(0), FQ(RWTableTag.Start)) for i in range(MAX_RWS - len(rw_rows))
+    ]
 
     num_txs = 1
-    tx_padding = [TxTableRow(FQ(i+1), FQ(TxContextFieldTag.Pad), FQ(0), FQ(0)) for i in range((MAX_TXS - num_txs) * TxContextFieldTag.CallData)]
+    tx_padding = [
+        TxTableRow(FQ(i + 1), FQ(TxContextFieldTag.Pad), FQ(0), FQ(0))
+        for i in range((MAX_TXS - num_txs) * TxContextFieldTag.CallData)
+    ]
 
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),

--- a/tests/evm/test_end_block.py
+++ b/tests/evm/test_end_block.py
@@ -10,6 +10,8 @@ from zkevm_specs.evm import (
     RWTableRow,
     RW,
     CallContextFieldTag,
+    TxContextFieldTag,
+    TxTableRow,
     Block,
     Transaction,
 )
@@ -17,6 +19,10 @@ from zkevm_specs.util import rand_fq, FQ
 
 TESTING_DATA = (False, True)
 
+MAX_TXS = 2
+MAX_CALLDATA_BYTES = 0
+
+MAX_RWS = 64
 
 @pytest.mark.parametrize("is_last_step", TESTING_DATA)
 def test_end_block(is_last_step: bool):
@@ -24,18 +30,20 @@ def test_end_block(is_last_step: bool):
 
     tx = Transaction()
 
+    # dummy read/write for counting
+    rw_rows = [RWTableRow(FQ(i), *9 * [FQ(0)]) for i in range(22)]
+    if is_last_step:
+        rw_rows.append(RWTableRow(FQ(22), FQ(RW.Read), FQ(RWTableTag.CallContext), FQ(1), FQ(CallContextFieldTag.TxId), value=FQ(tx.id)))
+    rw_padding = [RWTableRow(FQ(i+1), FQ(0), FQ(RWTableTag.Start)) for i in range(MAX_RWS - len(rw_rows))]
+
+    num_txs = 1
+    tx_padding = [TxTableRow(FQ(i+1), FQ(TxContextFieldTag.Pad), FQ(0), FQ(0)) for i in range((MAX_TXS - num_txs) * TxContextFieldTag.CallData)]
+
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),
-        tx_table=set(tx.table_assignments(randomness)),
+        tx_table=set(tx_padding + list(tx.table_assignments(randomness))),
         bytecode_table=set(),
-        rw_table=set(
-            chain(
-                # dummy read/write for counting
-                [RWTableRow(FQ(i), *9 * [FQ(0)]) for i in range(22)],
-                [RWTableRow(FQ(22), FQ(RW.Read), FQ(RWTableTag.CallContext), FQ(1), FQ(CallContextFieldTag.TxId), value=FQ(tx.id))]  # fmt: skip
-                if is_last_step else [],
-            )
-        ),
+        rw_table=set(rw_padding + rw_rows),
     )
 
     verify_steps(


### PR DESCRIPTION
The main change is using 2 strategic lookups to the padding rows with sequential numbers to prove a lower bound on padding rows which allows proving the number of rw operations in the rw_table and txs in the tx table; as devised by @z2trillion in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/558

NOTE: To implement this spec, EndBlock needs to be height = 1, which can be achieved after reducing the number of cells used in the state selector in the EVM circuit (by increasing the selector expression degree by 1).

Resolve https://github.com/privacy-scaling-explorations/zkevm-specs/issues/231