### PR TITLE
opcode EXP

### DIFF
--- a/specs/copy-proof.md
+++ b/specs/copy-proof.md
@@ -16,6 +16,7 @@ In addition to the columns in the copy table, copy circuit adds a few auxiliary 
 - `is_tx_calldata`: indicates if `Type` is `TxCalldata` using `IsZero` gadget.
 - `is_tx_log`: indicates if `Type` is `TxLog` using `IsZero` gadget.
 - `is_rlc_acc`: indicates if `Type` is `RlcAcc` using `IsZero` gadget.
+- `is_exp`: indicates if `Type` is `Exp` using `IsZero` gadget.
 
 *Note*: We use `IsZero` gadget in the specs for simplicity. In the actual circuit implementation, we make use of `BinaryGadget`.
 
@@ -28,16 +29,17 @@ First, the circuit adds common constraints that applied to every rows in the cir
 - Boolean check for `is_first`, and `is_last`
 - Check `is_first == 0` when `q_step == 0`
 - Check `is_last == 0` when `q_step == 1`
-- Construct the `IsZero` gadget and constrain `is_memory`, `is_bytecode`, `is_tx_calldata`, `is_tx_log` and `is_rlc_acc`.
+- Construct the `IsZero` gadget and constrain `is_memory`, `is_bytecode`, `is_tx_calldata`, `is_tx_log`, `is_rlc_acc` and `is_exp`.
 - The transition constraints from a copy step to the next step (with 2-row rotation), applied to all rows except the last two rows (the last step) in a copy event:
     - `ID`, `Type`, `AddressEnd` should be same between two steps.
     - `Address` increase by 1 in the next copy step.
 - The transition constraints for `RwCounter` and `RwcIncreaseLeft` column
     - define `rw_diff` to be 1 if the `Type` is `Memory` or `TxLog` and `Padding` is 0 in the current row; otherwise 0.
     - when it's not the last row in a copy event (`is_last == 0`), `RwCounter` increases by `rw_diff` and `RwcIncreaseLeft` decrases by `rw_diff`.
-    - over all rows, the `rlc_acc` remains the same.
+    - over all rows, the `aux_value` remains the same.
     - when it's the last row in a copy event (`is_last == 1`), `RwcIncreaseLeft` is equal to `rw_diff`.
-    - when it's the last row of a copy event (`is_last == 1`) and `is_rlc_acc == 1`, the row `value` should equal the row `rlc_acc`.
+    - when it's the last row of a copy event (`is_last == 1`) and `is_rlc_acc == 1`, the row `value` should equal the row `aux_value`.
+    - when it's the last row of a copy event (`is_last == 1`) and `is_exp == 1`, the row `value` should equal the row `aux_value`.
 
 Second, the circuit adds the constraints for every copy step in the circuit, when `q_step` is 1.
 
@@ -45,8 +47,8 @@ Second, the circuit adds the constraints for every copy step in the circuit, whe
 - Constrain the transition for `BytesLeft`
     - when it's not the last step (`is_last[1] != 1`), decrease by 1 in the next step
     - otherwise, equals to 1.
-- For all cases except `is_rlc_acc == 1`, we have `Value[0] == Value[1]`, meaning that read `value` equates write `value`.
-- For `is_rlc_acc == 1`, we have `Value[0] == Value[1]` only for the first row, i.e. `is_first == 1`.
+- For all cases except `is_rlc_acc == 1 or is_exp == 1`, we have `Value[0] == Value[1]`, meaning that read `value` equates write `value`.
+- For `is_rlc_acc == 1 or is_exp == 1`, we have `Value[0] == Value[1]` only for the first row, i.e. `is_first == 1`.
 - Constrain `Value == 0` when `Padding == 1`.
 - Construct the LT gadget to compare `Address` and `AddressEnd` in the read operation. If `Address >= AddressEnd`, constrain `Padding == 1`
 - Constrain `Padding[1] == 0` as the write operation is never padded.
@@ -56,7 +58,12 @@ Third, the circuit adds constraints for every copy step in the circuit, when `q_
 - Constraint the next write `value` by:
     - `Value[2] == Value[0] * r + Value[1]`
 
-Fourth, the circuit adds the lookup arguments to the corresponding tables.
+Fourth, the circuit adds constraints for every copy step in the circuit, when `q_step == 0` (write row). These constraints are only added for the `is_exp == 1` case, for all except the last row, i.e. `is_last == 0`.
+
+- Constraint the next write `value` by:
+    - `Value[2] == Value[0] * Value[1]`
+
+Fifth, the circuit adds the lookup arguments to the corresponding tables.
 
 - When `Type` is `Memory` or `is_memory == 1` and `Padding == 0`, look up the `Value` to `rw_table` with `Memory` tag.
 - When `Type` is `TxCalldata` or `is_tx_calldata == 1` and `Padding == 0`, look up the `Value` to `tx_table`.

--- a/src/zkevm_specs/evm/execution/__init__.py
+++ b/src/zkevm_specs/evm/execution/__init__.py
@@ -19,6 +19,7 @@ from .calldatacopy import *
 from .calldataload import *
 from .codecopy import *
 from .codesize import *
+from .exp import exp
 from .gas import *
 from .iszero import *
 from .jump import *
@@ -49,6 +50,7 @@ EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.ADDMOD: addmod,
     ExecutionState.MULMOD: mulmod,
     ExecutionState.MUL: mul_div_mod,
+    ExecutionState.EXP: exp,
     ExecutionState.NOT: not_opcode,
     ExecutionState.ORIGIN: origin,
     ExecutionState.CALLER: caller,

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -1,6 +1,6 @@
 from ..instruction import Instruction, Transition
 from ..table import CopyDataTypeTag
-from zkevm_specs.util import FQ
+from zkevm_specs.util import FQ, GAS_COST_EXP, byte_size
 
 
 def exp(instruction: Instruction):
@@ -10,6 +10,7 @@ def exp(instruction: Instruction):
     base_rlc = instruction.stack_pop()
     # integer exponent, RLC encoded
     exponent_rlc = instruction.stack_pop()
+    exponent = instruction.rlc_to_fq(exponent_rlc, n_bytes=31)
     # integer result of the exponential operation modulo 2**256, RLC encoded
     exp_rlc = instruction.stack_push()
 
@@ -19,17 +20,16 @@ def exp(instruction: Instruction):
         instruction.curr.call_id,
         CopyDataTypeTag.Exp,
         FQ.zero(),
-        instruction.rlc_to_fq(exponent_rlc, n_bytes=31),
+        exponent,
         FQ.zero(),
-        instruction.rlc_to_fq(exponent_rlc, n_bytes=31),
+        exponent,
         instruction.curr.rw_counter + instruction.rw_counter_offset,
     )
 
     instruction.constrain_zero(copy_rwc_inc)
     instruction.constrain_equal(exp_rlc, instruction.rlc_encode(aux_value, n_bytes=32))
 
-    # TODO(rohit): 50 * exponent_byte_size
-    dynamic_gas_cost = 0
+    dynamic_gas_cost = GAS_COST_EXP * byte_size(exponent.n)
 
     instruction.step_state_transition_in_same_context(
         opcode,

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -1,0 +1,40 @@
+from ..instruction import Instruction, Transition
+from ..table import CopyDataTypeTag
+from zkevm_specs.util import FQ
+
+
+def exp(instruction: Instruction):
+    opcode = instruction.opcode_lookup(True)
+
+    # integer base, RLC encoded
+    base_rlc = instruction.stack_pop()
+    # integer exponent, RLC encoded
+    exponent_rlc = instruction.stack_pop()
+    # integer result of the exponential operation modulo 2**256, RLC encoded
+    exp_rlc = instruction.stack_push()
+
+    copy_rwc_inc, aux_value = instruction.copy_lookup(
+        instruction.curr.call_id,
+        CopyDataTypeTag.Exp,
+        instruction.curr.call_id,
+        CopyDataTypeTag.Exp,
+        FQ.zero(),
+        instruction.rlc_to_fq(exponent_rlc, n_bytes=31),
+        FQ.zero(),
+        instruction.rlc_to_fq(exponent_rlc, n_bytes=31),
+        instruction.curr.rw_counter + instruction.rw_counter_offset,
+    )
+
+    instruction.constrain_zero(copy_rwc_inc)
+    instruction.constrain_equal(exp_rlc, instruction.rlc_encode(aux_value, n_bytes=32))
+
+    # TODO(rohit): 50 * exponent_byte_size
+    dynamic_gas_cost = 0
+
+    instruction.step_state_transition_in_same_context(
+        opcode,
+        rw_counter=Transition.delta(3),
+        program_counter=Transition.delta(1),
+        stack_pointer=Transition.delta(1),
+        dynamic_gas_cost=dynamic_gas_cost,
+    )

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1037,7 +1037,7 @@ class Instruction:
             rw_counter,
             log_id,
         )
-        return copy_table_row.rwc_inc, copy_table_row.rlc_acc
+        return copy_table_row.rwc_inc, copy_table_row.aux_value
 
     def keccak_lookup(self, length: Expression, value_rlc: Expression) -> FQ:
         return self.tables.keccak_lookup(length, value_rlc).output

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -298,6 +298,14 @@ class CopyDataTypeTag(IntEnum):
     # the Keccak table for the SHA3 of the input bytes.
     RlcAcc = auto()
 
+    # Exponentiation tag is reserved for cases where every
+    # written value is a product of the previous row's written
+    # value and the corresponding read value. It is being used
+    # for the EXP opcode where for (a ** exponent) we have every
+    # read value as `a` with a total of `exponent` number of
+    # rows.
+    Exp = auto()
+
 
 class WrongQueryKey(Exception):
     def __init__(self, table_name: str, diff: Set[str]) -> None:
@@ -397,7 +405,7 @@ class CopyCircuitRow(TableRow):
     src_addr_end: FQ
     bytes_left: FQ
     value: FQ
-    rlc_acc: FQ
+    aux_value: FQ
     is_code: FQ
     is_pad: FQ
     rw_counter: FQ
@@ -407,6 +415,7 @@ class CopyCircuitRow(TableRow):
     is_tx_calldata: FQ
     is_tx_log: FQ
     is_rlc_acc: FQ
+    is_exp: FQ
 
 
 @dataclass(frozen=True)
@@ -419,7 +428,7 @@ class CopyTableRow(TableRow):
     src_addr_end: FQ
     dst_addr: FQ
     length: FQ
-    rlc_acc: FQ
+    aux_value: FQ
     rw_counter: FQ
     rwc_inc: FQ
 
@@ -485,7 +494,7 @@ class Tables:
                         src_addr_end=first_row.src_addr_end,
                         dst_addr=next_row.addr,
                         length=first_row.bytes_left,
-                        rlc_acc=row.rlc_acc,
+                        aux_value=row.aux_value,
                         rw_counter=first_row.rw_counter,
                         rwc_inc=first_row.rwc_inc_left,
                     )

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -770,7 +770,7 @@ class CopyCircuit:
                 dst_type,
                 dst_addr + i,
                 aux_value if dst_type in [CopyDataTypeTag.RlcAcc, CopyDataTypeTag.Exp] else value,
-                FQ.zero(),
+                FQ.zero(),  # aux_value will be updated later
                 is_code,
                 False,
                 log_id=log_id,

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -7,7 +7,7 @@ from .constraint_system import *
 from .hash import *
 from .param import *
 from .typing import *
-from .testing import memory_expansion, memory_word_size
+from .testing import byte_size, memory_expansion, memory_word_size
 
 
 def rand_range(stop: Union[int, float] = 2**256) -> int:

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -33,6 +33,8 @@ GAS_COST_SLOW = 10
 GAS_COST_EXT = 20
 # Gas cost of SHA3
 GAS_COST_SHA3 = 30
+# Dynamic gas multiplier for EXP opcode
+GAS_COST_EXP = 50
 # Gas cost of CREATE
 GAS_COST_CREATE = 32000
 # Gas cost of CREATE2

--- a/src/zkevm_specs/util/testing.py
+++ b/src/zkevm_specs/util/testing.py
@@ -9,6 +9,10 @@ def memory_word_size(
     return U64((address + 31) // 32)
 
 
+def byte_size(value: int) -> int:
+    return (value.bit_length() + 7) // 8
+
+
 def div(
     value: U256,
     divisor: U64,

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -1,0 +1,114 @@
+import pytest
+
+from zkevm_specs.evm import (
+    Block,
+    Bytecode,
+    CopyCircuit,
+    CopyDataTypeTag,
+    ExecutionState,
+    Opcode,
+    RWDictionary,
+    StepState,
+    Tables,
+    verify_steps,
+)
+from zkevm_specs.copy_circuit import verify_copy_table
+from zkevm_specs.util import (
+    rand_fq,
+    rand_range,
+    FQ,
+    RLC,
+)
+
+
+CALL_ID = 1
+TESTING_DATA = (
+    (0x03, 0x04),
+    (0x05, 0x101),
+    (0x101, 0x202),
+    (rand_range(2**64), rand_range(256)),
+)
+
+
+@pytest.mark.parametrize("base, exponent", TESTING_DATA)
+def test_exp(base: int, exponent: int):
+    randomness = rand_fq()
+
+    bytecode = Bytecode().push(exponent, n_bytes=32).push(base, n_bytes=32).exp().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
+    pc_exp = 66
+
+    base_rlc = RLC(base, randomness)
+    exponent_rlc = RLC(exponent, randomness)
+    exp = FQ(base) ** exponent
+    exp_rlc = RLC(exp.n, randomness)
+
+    rw_dictionary = (
+        RWDictionary(1)
+        .stack_write(CALL_ID, 1023, exponent_rlc)
+        .stack_write(CALL_ID, 1022, base_rlc)
+        .stack_read(CALL_ID, 1022, base_rlc)
+        .stack_read(CALL_ID, 1023, exponent_rlc)
+        .stack_write(CALL_ID, 1023, exp_rlc)
+    )
+    rw_counter_interim = rw_dictionary.rw_counter
+
+    data = dict([(i, base) for i in range(0, exponent)])
+    copy_circuit = CopyCircuit().copy(
+        randomness,
+        rw_dictionary,
+        CALL_ID,
+        CopyDataTypeTag.Exp,
+        CALL_ID,
+        CopyDataTypeTag.Exp,
+        FQ.zero(),
+        exponent,
+        FQ.zero(),
+        exponent,
+        data,
+    )
+    assert rw_dictionary.rw_counter == rw_counter_interim
+
+    tables = Tables(
+        block_table=set(Block().table_assignments(randomness)),
+        tx_table=set(),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
+        rw_table=set(rw_dictionary.rws),
+        copy_circuit=copy_circuit.rows,
+    )
+
+    verify_copy_table(copy_circuit, tables, randomness)
+
+    gas = (
+        Opcode.EXP.constant_gas_cost()
+        # TODO(rohit): dynamic gas cost
+        + 0
+    )
+    verify_steps(
+        randomness=randomness,
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.EXP,
+                rw_counter=3,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=pc_exp,
+                stack_pointer=1022,
+                gas_left=gas,
+            ),
+            StepState(
+                execution_state=ExecutionState.STOP,
+                rw_counter=rw_dictionary.rw_counter,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=pc_exp + 1,
+                stack_pointer=1023,
+                gas_left=0,
+            ),
+        ],
+    )

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -14,9 +14,11 @@ from zkevm_specs.evm import (
 )
 from zkevm_specs.copy_circuit import verify_copy_table
 from zkevm_specs.util import (
+    byte_size,
     rand_fq,
     rand_range,
     FQ,
+    GAS_COST_EXP,
     RLC,
 )
 
@@ -79,11 +81,7 @@ def test_exp(base: int, exponent: int):
 
     verify_copy_table(copy_circuit, tables, randomness)
 
-    gas = (
-        Opcode.EXP.constant_gas_cost()
-        # TODO(rohit): dynamic gas cost
-        + 0
-    )
+    gas = Opcode.EXP.constant_gas_cost() + (GAS_COST_EXP * byte_size(exponent))
     verify_steps(
         randomness=randomness,
         tables=tables,


### PR DESCRIPTION
### Addition

The copy circuit has been modified to add a `Exp` row type.

This type is constrained with:
```
write_value::next == write_value::cur * read_value::cur
```

For all `read` values being equal (`base`) and the number of `write` rows being equal to `exponent`, we have the final value equals `base ** exponent` which is the exponentiation result.

### Modification

Since the extra column (previously called `rlc_acc`) is used for multiple purposes now, it has been renamed to `aux_value` to denote an auxiliary value. The auxiliary value can be an RLC accumulator (for `RlcAcc`) or can be the exponentiation (for `Exp`). It's set to `FQ.zero()` for all other cases.