### PR TITLE
fix: constraint system fix | related fixes in copy circuit

### DIFF
--- a/src/zkevm_specs/evm/execution/sha3.py
+++ b/src/zkevm_specs/evm/execution/sha3.py
@@ -16,19 +16,22 @@ def sha3(instruction: Instruction):
     # convert RLC encoded stack elements to FQ.
     memory_offset, length = instruction.memory_offset_and_length(offset, size)
 
-    copy_rwc_inc, rlc_acc = instruction.copy_lookup(
-        instruction.curr.call_id,
-        CopyDataTypeTag.Memory,
-        instruction.curr.call_id,
-        CopyDataTypeTag.RlcAcc,
-        memory_offset,
-        memory_offset + length,
-        FQ.zero(),
-        length,
-        instruction.curr.rw_counter + instruction.rw_counter_offset,
-    )
-    keccak256_rlc_acc = instruction.keccak_lookup(length, rlc_acc)
+    if instruction.is_zero(length) == FQ.zero():
+        copy_rwc_inc, rlc_acc = instruction.copy_lookup(
+            instruction.curr.call_id,
+            CopyDataTypeTag.Memory,
+            instruction.curr.call_id,
+            CopyDataTypeTag.RlcAcc,
+            memory_offset,
+            memory_offset + length,
+            FQ.zero(),
+            length,
+            instruction.curr.rw_counter + instruction.rw_counter_offset,
+        )
+    else:
+        copy_rwc_inc, rlc_acc = FQ.zero(), FQ.zero()
 
+    keccak256_rlc_acc = instruction.keccak_lookup(length, rlc_acc)
     instruction.constrain_equal(
         keccak256_rlc_acc,
         sha3_value.expr(),

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -690,9 +690,11 @@ class CopyCircuit:
     rows: List[CopyCircuitRow]
     pad_rows: List[CopyCircuitRow]
 
-    def __init__(self) -> None:
+    def __init__(self, pad_rows: Optional[List[CopyCircuitRow]] = None) -> None:
         self.rows = []
-        self.pad_rows = [CopyCircuitRow(FQ(1), *[FQ(0)] * 18), CopyCircuitRow(*[FQ(0)] * 19)]
+        self.pad_rows = []
+        if pad_rows is not None:
+            self.pad_rows = pad_rows
 
     def table(self) -> Sequence[CopyCircuitRow]:
         return self.rows + self.pad_rows
@@ -805,7 +807,7 @@ class CopyCircuit:
         if is_memory:
             if is_write:
                 rw_dict.memory_write(id, addr, value)
-            else:
+            elif is_pad is False:
                 rw_dict.memory_read(id, addr, value)
         elif is_tx_log:
             assert is_write

--- a/src/zkevm_specs/util/constraint_system.py
+++ b/src/zkevm_specs/util/constraint_system.py
@@ -29,7 +29,7 @@ class ConstraintSystem:
         return expr.expr()
 
     def constrain_equal(self, lhs: Expression, rhs: Expression):
-        assert self._eval(lhs.expr()) == self._eval(rhs.expr()), ConstraintUnsatFailure(
+        assert self._eval(lhs.expr() - rhs.expr()) == 0, ConstraintUnsatFailure(
             f"Expected values to be equal, but got {lhs} and {rhs}"
         )
 

--- a/src/zkevm_specs/util/constraint_system.py
+++ b/src/zkevm_specs/util/constraint_system.py
@@ -17,7 +17,9 @@ class ConstraintSystem:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, e_type, e_value, traceback):
+        if e_type is not None:
+            raise e_value
         self.cond = None
         return self
 
@@ -27,7 +29,7 @@ class ConstraintSystem:
         return expr.expr()
 
     def constrain_equal(self, lhs: Expression, rhs: Expression):
-        assert self._eval(lhs.expr() - rhs.expr()) == 0, ConstraintUnsatFailure(
+        assert self._eval(lhs.expr()) == self._eval(rhs.expr()), ConstraintUnsatFailure(
             f"Expected values to be equal, but got {lhs} and {rhs}"
         )
 

--- a/tests/evm/test_sha3.py
+++ b/tests/evm/test_sha3.py
@@ -28,7 +28,11 @@ from zkevm_specs.util import (
 
 
 CALL_ID = 1
-TESTING_DATA = ((0x20, 0x40),)
+TESTING_DATA = (
+    (0x20, 0x40),
+    (0x101, 0x202),
+    (0x202, 0x00),
+)
 
 
 @pytest.mark.parametrize("offset, length", TESTING_DATA)


### PR DESCRIPTION
The following fixes have been made in this PR:
- Exceptions (eg. assertion) from within a `cs.condition` were not raised since the `__exit__` did not raise them. This meant, we were never warned about nested conditions not allowed, and any constraint failure within a condition was also completely ignored.
- `CALLDATACOPY` memory read was added even for `is_pad = True`
- Remove nested conditions
- `SHA3` gadget should do a copy table lookup only if `length > 0`. Otherwise `copy_rwc_inc = rlc_acc = 0`