### PR TITLE
Exponentiation circuit and EXP opcode

### DIFF
--- a/specs/exp-proof-design-doc.md
+++ b/specs/exp-proof-design-doc.md
@@ -1,4 +1,4 @@
-# Exponentiation Circuit
+# Exponentiation Proof Design Document
 
 The Exponentiation Circuit is a sub-circuit within the [`SuperCircuit`](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/super_circuit.rs) used to validate exponentiation, particularly required for the [`EXP`](https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27z1~2~10wyyz2~2~2w%27~yPUSH1%20z%2F%2F%20Example%20y%5CnwyEXP%01wyz~_) opcode gadget within the [`EVM Circuit`](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit.rs).
 

--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -56,7 +56,7 @@ The exponentiation circuit consists of the following columns:
         - `exponent` MUST reduce to `exponent // 2`, which means:
 	    - Low 128 bits of `exponent::cur` MUST equal low 128 bits of `parity_check`'s multiplication result `d`.
 	        - That is, `exp_table.exponent_lo == parity_check.d_lo`.
-	    - High 128 bits of `exponent::cur` MUST equal high 128 bits of `parity_check's multiplication result `d`.
+	    - High 128 bits of `exponent::cur` MUST equal high 128 bits of `parity_check`'s multiplication result `d`.
 	        - That is, `exp_table.exponent_hi == parity_check.d_hi`.
 	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `parity_check`'s multiplicand `q`.
 	        - That is, `exp_table.exponent_lo::next == parity_check.q_lo`. We compute `q_lo` using the 64-bit limbs of `q`.

--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -21,46 +21,56 @@ For a detailed algorithm, please refer the [design document](https://hackmd.io/@
 
 ## Circuit Layout
 
-The exponentiation circuit contains columns from the [exponentiation table](./tables.md#exponentiation-table) in addition to the following columns:
-1. `q_step`: A selector to indicate whether or not the current row represents a step in the exponentiation trace.
-2. `is_pad`: A boolean-valued advice column to indicate whether or not the step is reserved for padding or not.
-3. `is_odd`: a boolean-valued advice column to indicate whether or not the exponent at this step is odd or even.
-4. `quotient`: An RLC field representing the quotient in `2 * q + is_odd == exponent`.
-
-We even use a few columns to perform multiplication (modulo `2^256`) of the intermediate steps in the exponentiation trace.
+The exponentiation circuit consists of the following columns:
+1. `q_usable`: A selector to indicate whether or not the current row will be used in the circuit's layout.
+2. `exp_table`: The columns from [exponentiation table](./tables.md#exponentiation-table)
+3. `mul_gadget`: The columns from a multiplication gadget, responsible for validating that each step within the exponentiation trace was multiplied correctly. For instance, in the above example we would want to verify that `729 * 729 == 531441 (mod 2^256)`.
+4. `parity_check`: The columns from a multiplication gadget, responsible for checking the parity (odd/even) of the `exponent` at the specific step of exponentiation trace. Depending on whether the `exponent` is odd or even, we calculate the `exponent` at the next step.
 
 ## Circuit Constraints
 
-- For every step except the last step, validate that:
+- For every row where `is_step == true`, except the last step, validate that:
     - `base` MUST be the same across subsequent steps.
     - Multiplication result `d` from the next row MUST be equal to the first multiplicand `a` in the current row. For instance, if we consider `row_0` (`531441 * 3 = 1594323`) and `row_1` (`729 * 729 = 531441`) from the above example, `d_1` is `531441` and `a_0` is also `531441`.
-    - `identifier` MUST be the same across subsequent steps.
+    - `identifier` MUST be the same across subsequent steps, i.e. `identifier::cur_step == identifier::next_step`.
 
-- For every step, validate that:
-    - `is_last` MUST be boolean.
-    - `is_pad` MUST be boolean.
-    - `is_odd` MUST be boolean.
-    - `is_last == 1` MUST be followed by a padding row, i.e. `is_pad::next == 1`.
-    - `is_last == 0` MUST be followed by a non-padding row, i.e. `is_pad::next == 0`.
-    - The multiplication `a * b + c == d` MUST be assigned correctly, where `c == 0`.
-    - At every intermediate step in the exponentiation trace, the `exponentiation` MUST be equal to `d`, which is the result of the multiplication.
-    - The multiplication `2 * q + is_odd == exponent` MUST be correct.
+- For every row, validate that:
+    - `exp_table.is_step` MUST be boolean.
+    - `exp_table.is_last` MUST be boolean.
 
-- For every step except the last step where `is_odd == 1`:
-    - The second multiplicand in the multiplication `b` MUST be equal to `base`.
-    - `exponent::next == exponent::cur - 1`, which implies:
-        - `exponent_lo::next == exponent_lo::cur - 1`.
-	- `exponent_hi::next == exponent_hi::cur`.
-
-- For every step except the last step where `is_odd == 0`:
-    - Both the multiplicands in the multiplication `a` and `b` MUST be equal, i.e. `a == b`.
-    - `exponent::next == exponent::cur // 2`, which implies:
-        - `exponent_lo::next == quotient_lo`.
-	- `exponent_hi::next == quotient_hi`.
-
-- For the last step in the exponentiation trace, i.e. `is_last == 1`:
-    - The exponent has reduced to `2`, i.e. `exponent_lo == 2` and `exponent_hi == 0`.
-    - Both multiplicands in the multiplication are equal to the `base` of the exponentiation operation, i.e. `a == b == base`.
+- For every row where `is_step == true`, validate that:
+    - `exponentiation_lo` MUST equal `mul_gadget`'s multiplication result `d_lo`.
+    - `exponentiation_hi` MUST equal `mul_gadget`'s multiplication result `d_hi`.
+    - Since we are only performing multiplication with the equation `a * b + c == d`, `c` in the `mul_gadget` MUST equal `0`.
+    - Since we are performing `2 * q + r == exponent` in the `parity_check` multiplication gadget, `r` is boolean, that is:
+        - `r_hi` MUST equal `0`.
+	- `r_lo` MUST be boolean.
+	- `overflow` in the `parity_check` MUST equal `0`.
+    - If parity check is `odd`, i.e. `parity_check.r_lo == 1`:
+        - `exponent` MUST reduce by 1, which means:
+	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `exponent::cur - 1`.
+	    - High 128 bits of `exponent::next` MUST equal high 128 bits of `exponent::cur`.
+	- `exponent` is odd also means it was a multiplication by `base` operation, that is:
+	    - For each limb, `exp_table.base_limb == mul_gadget.b`.
+    - If parity check if `even`, i.e. `parity_check.r_lo == 0`:
+        - `exponent` MUST reduce to `exponent // 2`, which means:
+	    - Low 128 bits of `exponent::cur` MUST equal low 128 bits of `parity_check`'s multiplication result `d`.
+	        - That is, `exp_table.exponent_lo == parity_check.d_lo`.
+	    - High 128 bits of `exponent::cur` MUST equal high 128 bits of `parity_check's multiplication result `d`.
+	        - That is, `exp_table.exponent_hi == parity_check.d_hi`.
+	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `parity_check`'s multiplicand `q`.
+	        - That is, `exp_table.exponent_lo::next == parity_check.q_lo`. We compute `q_lo` using the 64-bit limbs of `q`.
+	    - High 128 bits of `exponent::next` MUST equal high 128 bits of `parity_check`'s multiplicand `q`.
+	        - That is, `exp_table.exponent_hi::next == parity_check.q_hi`. We compute `q_hi` using the 64-bit limbs of `q`.
+	- `exponent` is even also means it was a squaring operation, that is:
+	    - `mul_gadget`'s multiplicands MUST be equal, or, `mul_gadget.a == mul_gadget.b`.
+    - For the last step, i.e. `is_last == true`, validate that `a * a == a^2 (mod 2^256)`:
+        - `exponent` MUST equal `2`, that is:
+	    - `exp_table.exponent_lo == 2`
+	    - `exp_table.exponent_hi == 0`
+	- Both multiplicand's of the `mul_gadget`, i.e. `a` and `b` MUST equal `base` of the exponentiation operation, that is:
+	    - `mul_gadget.a == base`
+	    - `mul_gadget.b == base` (for both these cases we equate each 64-bit limb)
 
 ## Code
 

--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -17,7 +17,7 @@ a * b + c = d
 ```
 while validating the equation using a `MulAddWordsGadget` where `c == 0`.
 
-For a detailed algorithm, please refer the [design document](https://hackmd.io/@rohitnarurkar/BJhpYGiCc).
+For a detailed algorithm, please refer the [design document](../specs/exp-proof-design-doc.md).
 
 ## Circuit Layout
 

--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -1,0 +1,65 @@
+# Exponentiation Proof
+
+The exponentiation proof validates entries in the exponentiation circuit, which includes the exponentiation table. Each `EXP` opcode performed in a block's transactions is mapped to an exponentiation trace, more specifically these are the intermediate multiplication steps produced while exponentiation by squaring.
+
+For instance, `3 ^ 13 == 1594323 (mod 2^256)` is mapped to the following steps:
+```
+3      * 3   = 9
+9      * 3   = 27
+27     * 27  = 729
+729    * 729 = 531441
+531441 * 3   = 1594323
+```
+
+Moving on, we refer each of the above multiplication steps as:
+```
+a * b + c = d
+```
+while validating the equation using a `MulAddWordsGadget` where `c == 0`.
+
+For a detailed algorithm, please refer the [design document](https://hackmd.io/@rohitnarurkar/BJhpYGiCc).
+
+## Circuit Layout
+
+The exponentiation circuit contains columns from the [exponentiation table](./tables.md#exponentiation-table) in addition to the following columns:
+1. `q_step`: A selector to indicate whether or not the current row represents a step in the exponentiation trace.
+2. `is_pad`: A boolean-valued advice column to indicate whether or not the step is reserved for padding or not.
+3. `is_odd`: a boolean-valued advice column to indicate whether or not the exponent at this step is odd or even.
+4. `fixed_table`: A set of 2 fixed columns spanning over 128 rows, reserved for odd/even byte-values. The odd table will consist of values `{1, 3, 5, ..., 253, 255}` and the even table will consist of values `{0, 2, 4, ..., 252, 254}`.
+
+We even use a few columns to perform multiplication (modulo `2^256`) of the intermediate steps in the exponentiation trace.
+
+## Circuit Constraints
+
+- For every step except the last step, validate that:
+    - `base` MUST be the same across subsequent steps.
+    - Multiplication result `d` from the next row MUST be equal to the first multiplicand `a` in the current row. For instance, if we consider `row_0` (`531441 * 3 = 1594323`) and `row_1` (`729 * 729 = 531441`) from the above example, `d_1` is `531441` and `a_0` is also `531441`.
+
+- For every step, validate that:
+    - `is_first` and `is_last` MUST be boolean.
+    - `is_first == 1` MUST be followed by `is_first::next == 0`.
+    - `is_first == 0` MUST be followed by `is_first::next == 0`.
+    - `is_last == 1` MUST be followed by a padding row, i.e. `is_pad::next == 1`.
+    - The multiplication `a * b + c == d` MUST be assigned correctly, where `c == 0`.
+    - At every intermediate step in the exponentiation trace, the `exponentiation` MUST be equal to `d`, which is the result of the multiplication.
+    - `is_odd` MUST be boolean.
+
+- For every step except the last step where `is_odd == 1`:
+    - The second multiplicand in the multiplication `b` MUST be equal to `base`.
+    - `exponent::next == exponent::cur - 1`, which implies:
+        - `exponent_lo::next == exponent_lo::cur - 1`.
+	- `exponent_hi::next == exponent_hi::cur`.
+
+- For every step except the last step where `is_odd == 0`:
+    - Both the multiplicands in the multiplication `a` and `b` MUST be equal, i.e. `a == b`.
+    - `exponent::next == exponent::cur // 2`, which implies:
+        - `exponent_lo::next * 2 == exponent_lo::cur`.
+	- `exponent_hi::next * 2 == exponent_hi::cur`.
+
+- For the last step in the exponentiation trace, i.e. `is_last == 1`:
+    - The exponent has reduced to `2`, i.e. `exponent_lo == 2` and `exponent_hi == 0`.
+    - Both multiplicands in the multiplication are equal to the `base` of the exponentiation operation, i.e. `a == b == base`.
+
+## Code
+
+Please refer to [Exponentiation Circuit Verification](`src/zkevm-specs/exp_circuit.py`).

--- a/specs/exponentiation-circuit.md
+++ b/specs/exponentiation-circuit.md
@@ -247,7 +247,7 @@ We make use of a cell called `most_significant_nonzero_byte_inverse` to store th
 ```
 sum(word_bytes[index'..32]) == 0
 ```
-which basically means that, all the other bytes from `index'` must be `0` (since in the little-endian representation of word, bytes beyong the byte-size will be `0`).
+which basically means that, all the other bytes from `index'` must be `0` (since in the little-endian representation of word, bytes beyond the byte-size will be `0`).
 * If `index' > 0` then:
 ```
 word_bytes[index'] * most_significant_nonzero_byte_inverse == 1

--- a/specs/exponentiation-circuit.md
+++ b/specs/exponentiation-circuit.md
@@ -1,0 +1,254 @@
+# Exponentiation Circuit
+
+The Exponentiation Circuit is a sub-circuit within the [`SuperCircuit`](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/super_circuit.rs) used to validate exponentiation, particularly required for the [`EXP`](https://www.evm.codes/playground?unit=Wei&codeType=Mnemonic&code=%27z1~2~10wyyz2~2~2w%27~yPUSH1%20z%2F%2F%20Example%20y%5CnwyEXP%01wyz~_) opcode gadget within the [`EVM Circuit`](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit.rs).
+
+## Why a separate sub-circuit
+
+For most EVM opcodes that are decomposed into multiple steps, we use the [`Copy Circuit`](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/copy_circuit.rs). Examples are `CALLDATACOPY`, `CODECOPY`, `SHA3`, `RETURN`, `LOG` to name a few.
+
+The copy circuit is designed to support read-write operations at every internal step, which for instance could be memory read, memory write, tx lookups, etc.
+
+In a similar way, the exponentiation operation can be decomposed into steps for exponentiation by squaring. However there are no read-write operations or lookups to any other table. Instead, at every step we must validate whether the multiplication was done appropriately.
+
+In order to separate these concerns and not complicate the constraints for the copy circuit, I believe it makes more sense to implement a separate sub-circuit to verify the exponentiation operation.
+
+## Background
+
+Define the exponentiation operation as:
+```
+base ^ exponent == exponentiation (mod 2^256)
+```
+where `base`, `exponent` and `exponentiation` are 256-bit EVM words.
+
+We define _exponentiation by squaring_ with the following pseudocode:
+```
+Function exp_by_squaring(x, n, intermediate_steps)
+    if n = 0  then return  1;
+    if n = 1  then return  x; 
+    
+    exp1 = exp_by_squaring(x, n // 2)
+    exp2 = exp1 * exp1
+    intermediate_steps.append((exp1, exp1, exp2))
+    
+    if n is even:
+        return exp2
+    if n is odd:
+        exp = x * exp2
+        intermediate_steps.append((exp2, x, exp))
+        return exp
+```
+
+For instance, consider the operation `3 ^ 13 == 1594323 (mod 2^256)`. This can be decomposed into the following multiplication steps:
+```
+3      * 3   == 9
+9      * 3   == 27
+27     * 27  == 729
+729    * 729 == 531441
+531441 * 3   == 1594323
+```
+
+Each of the above multiplication steps can be defined as:
+```
+a * b + c == d (mod 2^256)
+```
+where `a`, `b`, `c` and `d` are each 256-bit words and we have `c == 0`. We build and use a `MulAddGadget` to validate each of the steps.
+
+Considering each of the above steps, we have:
+* For the first step:
+    * `a == b == base`
+* For the last step:
+    * `d == exponentiation`
+
+***Note***: We will eventually populate our circuit with these steps in the reverse order, so that at the last row, we have `a == b == base` and at the first row we have `d == exponentiation`.
+
+--------------------------------------------------------
+
+## Exponentiation Circuit Layout
+
+Within the exponentiation circuit, our goal is to:
+* Verify that each multiplication step is computed correctly.
+* Verify that `c == 0` for each multiplication step.
+* Verify that for the first multiplication (last row), `a == b == base`
+* Verify that the intermediate exponentiation (each step of the _exponentiation by squaring_) is correct.
+* Verify that the intermediate exponent is divided by 2 correctly to yield the said remainder.
+
+We also use multiple rows for a single multiplication step to make the circuit prover-efficient, so to achieve this we use a selector `q_step` to mark any given row as the starting point of a step.
+
+We use the following columns/gadgets in the exponentiation circuit:
+##### Circuit
+* `q_usable`: Selector which when enabled indicates that the row is used in the exponentiation circuit's layout.
+##### Exponentiation Table (exp_table)
+* `is_step`: A boolean value indicating whether this row is the first row from the set of rows representing a step from the exponentiation trace.
+* `identifier`: An identifier to uniquely identify an exponentiation trace. As of now, we use the read-write counter after reading both stack elements as the identifier.
+* `is_last`: Indicates whether or not the step is the last step for this exponentiation operation.
+* `base_limbs[i]`: Four columns representing the `base` as 64-bit limbs.
+* `exponent_lo_hi[i]`: Two columns representing the `exponent` as 128-bit low and high components.
+* `exponentiation_lo_hi[i]`: Two columns representing the `exponentiation` result as 128-bit low and high components.
+##### MulAddGadget (mul_gadget) for `a*b + c == d (mod 2^256)`
+* `a_limbs[i]`: Four columns representing `a` as 64-bit limbs, used for each multiplication step.
+* `b_limbs[i]`: Four columns representing `b` as 64-bit limbs, used for each multiplication step.
+* `c_lo_hi[i]`: Two columns representing `c` as 128-bit low and high components. Both `c_lo` and `c_hi` are equal to `0`.
+* `d_lo_hi[i]`: Two columns representing `d` as 128-bit low and high components.
+##### MulAddGadget (parity_check) for `2*q + r == exponent (mod 2^256)`
+* Similar as above, and `a == 2`, `c == 0`, `d == exponent`.
+
+--------------------------------------------------------
+
+### MulAddGadget
+
+We use multiple rows to layout the `MulAddGadget` and it looks as follows:
+| q_step | col0      | col1      | col2      | col3      | col4      |
+|--------|-----------|-----------|-----------|-----------|-----------|
+| 1      | a_limb0   | a_limb1   | a_limb2   | a_limb3   | -         |
+| 0      | b_limb0   | b_limb1   | b_limb2   | b_limb3   | -         |
+| 0      | c_lo      | c_hi      | d_lo      | d_hi      | -         |
+| 0      | carry_lo0 | carry_lo1 | carry_lo2 | carry_lo3 | carry_lo4 |
+| 0      | carry_lo5 | carry_lo6 | carry_lo7 | carry_lo8 | -         |
+| 0      | carry_hi0 | carry_hi1 | carry_hi2 | carry_hi3 | carry_hi4 |
+| 0      | carry_hi5 | carry_hi6 | carry_hi7 | carry_hi8 | -         |
+
+So effectively we use a total of 5 columns, namely `col0`, `col1`, `col2`, `col3` and `col4`, while splitting the limbs of `a` and `b` and low-high components of `c` and `d` over consecutive rows. The `carry` fields are for handling carry-over values while computing the overflowing multiplication.
+
+Effectively, the `MulAddGadget` consumes 7 rows per step.
+
+--------------------------------------------------------
+
+### Exponentiation Table
+
+We use multiple rows to layout the `ExpTable` and it looks as follows:
+| is_step | identifier | is_last | base_limb  | exponent_lo_hi | exponentiation_lo_hi |
+|---------|------------|---------|------------|----------------|----------------------|
+| 1       | $rwc       | 0       | base_limb0 | exponent_lo    | exponentiation_lo    |
+| 0       | $rwc       | 0       | base_limb1 | exponent_hi    | exponentiation_hi    |
+| 0       | $rwc       | 0       | base_limb2 | 0              | 0                    |
+| 0       | $rwc       | 0       | base_limb3 | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 1       | $rwc       | 0       | base_limb0 | exponent_lo    | exponentiation_lo    |
+| 0       | $rwc       | 0       | base_limb1 | exponent_hi    | exponentiation_hi    |
+| 0       | $rwc       | 0       | base_limb2 | 0              | 0                    |
+| 0       | $rwc       | 0       | base_limb3 | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| ...     | $rwc       | 0       | ...        | ...            | ...                  |
+| 1       | $rwc       | 1       | base_limb0 | exponent_lo    | exponentiation_lo    |
+| 0       | $rwc       | 0       | base_limb1 | exponent_hi    | exponentiation_hi    |
+| 0       | $rwc       | 0       | base_limb2 | 0              | 0                    |
+| 0       | $rwc       | 0       | base_limb3 | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+| 0       | $rwc       | 0       | 0          | 0              | 0                    |
+
+***Note 3***: The exponentiation table uses 4 rows to represent each step, however we pad 3 more rows since the `MulAddGadget` uses 7 rows per step.
+
+We populate the exponentiation table in reverse order so that for the first row, we have:
+```
+is_step.       -> 1
+base           -> base_limbs[0..4]
+exponent       -> exponent_lo_hi[0..2]
+exponentiation -> exponentiation_lo_hi[0..2]
+```
+and hence a lookup to the exponentiation table at this row confirms the presence of `base`, `exponent` and `exponentiation` for:
+```
+base ^ exponent == exponentiation (mod 2^256)
+```
+
+The `exponent` field is assigned a reducing value of the `exponent` such that:
+* At the first step, `exponent == exponent`
+* For all subsequent steps:
+    * `exponent::cur == exponent::prev - 1` if `exponent::prev` is odd
+    * `exponent::cur == exponent::prev // 2` if `exponent::prev` is even
+    * `a == b` if `exponent` is even
+    * `b == base` if `exponent` is odd
+* At the last step, i.e. `is_last == 1`, we have:
+    * `exponent::cur == 2`
+    * `a == b == base`
+
+The `exponentiation` field is defined as the result of the multiplication step, so we have:
+* At the first row, `exponentiation == exponentiation`
+* For every subsequent step:
+    * `exponentiation::cur == mul_gadget.d`. But we represent the `exponentiation` value as two 128-bit low-high parts, hence:
+        * `exponentiation_lo::cur == mul_gadget.d_lo`
+        * `exponentiation_hi::cur == mul_gadget.d_hi`
+
+--------------------------------------------------------
+
+## `EXP` Opcode Gadget
+
+The `EXP` opcode's gadget is within the `EVM Circuit`.
+
+It uses the following columns:
+* `base`: RLC-encoded 32-byte word, popped from the stack
+* `exponent`: RLC-encoded 32-byte word, popped from the stack
+* `exponentiation`: RLC-encoded 32-byte word, pushed to the stack
+* `exponent_is_zero`: `IsZeroGadget` to check whether or not `exponent == 0`
+* `exponent_is_one`: `IsEqualGadget` to check whether or not `exponent == 1`
+* `single_step`: A boolean to indicate whether or not there will be a single step in the exponentiation trace. There is a single step if `exponent == 2`, which means we have `base * base == base^2 (mod 2^256)` as the only step. We use this to determine the `is_first` and `is_last` column values, while doing lookups to the exponentiation table.
+* `exponent_byte_size`: `ByteSizeGadget` to check the byte-size of `exponent`, i.e. the minimum number of bytes that are required to represent `exponent`. In python, the code for byte size would be:
+```
+byte_size_value = (value.bits() + 7) // 8
+```
+
+### Constraints
+
+* If `exponent == 0` then `exponentiation == 1`
+* If `exponent == 1` then `exponentiation == base`
+* If `exponent == 2` then:
+    * Do lookup to the `ExpTable`:
+    ```
+    (
+        is_last=1,
+        base_limbs,
+        exponent_lo_hi,
+        exponentiation_lo_hi
+    )
+    ```
+* If `exponent > 2` then:
+    * Do lookup to the `ExpTable`:
+    ```
+    (
+        is_last=0,
+        base_limbs,
+        exponent_lo_hi,
+        exponentiation_lo_hi,
+    )
+    ```
+    * Do lookup to the `ExpTable`:
+    ```
+    (
+        is_last=1,
+        base_limbs,
+        exponent_lo_hi=[2, 0],
+        exponentiation_lo_hi=[base_sq_lo, base_sq_hi],
+    )
+    ```
+    where `base_sq_lo` and `base_sq_hi` are the 128-bit low-high parts of `base ^ 2 (mod 2^256)`.
+* If `exponent == 0` then `exponent_byte_size == 0`
+* Gas cost `gas == constant_gas_cost(EXP) +  dynamic_gas_cost` where `dynamic_gas_cost == 50 * exponent_byte_size`.
+
+--------------------------------------------------------
+
+## Byte Size Gadget
+
+We wish to calculate an expression that represents the byte size of a 32-bytes RLC-encoded word.
+
+We make use of an array of 33 cells, called `most_significant_nonzero_byte_index`. In this array, exactly one cell will be turned on (set to `1`) while the rest are all `0`. The turned on cell indicates the index of the most significant non-zero byte in the 32-bytes word.
+
+If this index is such that `index > 0`, this means that the byte size is non-zero. Which also means that there exists an inverse of the byte at that index in the 32-bytes word.
+
+We make use of a cell called `most_significant_nonzero_byte_inverse` to store the inverse of the byte at the said index.
+
+### Constraints
+
+* Exactly one cell is turned on from the array `most_significant_nonzero_byte_index`.
+* For instance, if the above turned on index is `index'`, then we have:
+```
+sum(word_bytes[index'..32]) == 0
+```
+which basically means that, all the other bytes from `index'` must be `0` (since in the little-endian representation of word, bytes beyong the byte-size will be `0`).
+* If `index' > 0` then:
+```
+word_bytes[index'] * most_significant_nonzero_byte_inverse == 1
+```

--- a/specs/opcode/0AEXP.md
+++ b/specs/opcode/0AEXP.md
@@ -22,6 +22,7 @@ The `EXP` opcode performs an exponential operation. It reads the integer base `b
         - Do a lookup to exponentiation table for
 	```
 	(
+	    is_step=1,
 	    is_last=1,
 	    base_limbs,
 	    exponent_lo_hi,
@@ -32,6 +33,7 @@ The `EXP` opcode performs an exponential operation. It reads the integer base `b
         - Do a lookup to exponentiation table for:
 	```
 	(
+	    is_step=1,
 	    is_last=0,
 	    base_limbs,
 	    exponent_lo_hi,
@@ -41,6 +43,7 @@ The `EXP` opcode performs an exponential operation. It reads the integer base `b
 	- Do a lookup to exponentiation table for:
 	```
 	(
+	    is_step=1,
 	    is_last=1,
 	    base_limbs,
 	    exponent_lo_hi=[2, 0],

--- a/specs/opcode/0AEXP.md
+++ b/specs/opcode/0AEXP.md
@@ -1,0 +1,65 @@
+# EXP opcode
+
+## EVM Behaviour
+
+The `EXP` opcode performs an exponential operation. It reads the integer base `base` and integer exponent `exponent` from the top of the stack and pushes the exponentiation result, i.e. `base ^ exponent (mod 2^256)` to the top of the stack.
+
+## Constraints
+
+1. opId == 0x0A
+2. State Transition:
+    - rw_counter += 3
+    - stack_pointer += 1
+    - pc += 1
+    - gas -= static_gas + dynamic_gas, where:
+        - `static_gas = 10`
+        - `dynamic_gas = 50 * byte_size(exponent)`
+3. Lookups:
+    - `base` is at the top of the stack (Read from RW Table)
+    - `exponent` is at the second position of the stack (Read from RW Table)
+    - `exponentiation` is at the top of the stack (Write to RW Table)
+    - if `exponent == 2`:
+        - Do a lookup to exponentiation table for
+	```
+	(
+	    is_first=1,
+	    is_last=1,
+	    base_limbs,
+	    exponent_lo_hi,
+	    lsb_exponent,
+	    exponentiation_lo_hi,
+	)
+	```
+    - if `exponent > 2`:
+        - Do a lookup to exponentiation table for:
+	```
+	(
+	    is_first=1,
+	    is_last=0,
+	    base_limbs,
+	    exponent_lo_hi,
+	    lsb_exponent,
+	    exponentiation_lo_hi,
+	)
+	```
+	- Do a lookup to exponentiation table for:
+	```
+	(
+	    is_first=0,
+	    is_last=1,
+	    base_limbs,
+	    exponent_lo_hi=[2, 0],
+	    lsb_exponent=[2, 0],
+	    base_sq_lo_hi,
+	)
+	```
+	where `base_sq_lo_hi` are the 128-bit low-high parts of `base * base (mod 2^256)`
+
+## Exceptions
+
+1. Stack underflow: The stack is empty or contains only one element.
+2. Out of gas: The gas available is not sufficient to cover the cost of the exponentiation operation.
+
+## Code
+
+Please refer to [EXP gadget](../../src/zkevm_specs/evm/execution/exp.py)

--- a/specs/opcode/0AEXP.md
+++ b/specs/opcode/0AEXP.md
@@ -22,11 +22,9 @@ The `EXP` opcode performs an exponential operation. It reads the integer base `b
         - Do a lookup to exponentiation table for
 	```
 	(
-	    is_first=1,
 	    is_last=1,
 	    base_limbs,
 	    exponent_lo_hi,
-	    lsb_exponent,
 	    exponentiation_lo_hi,
 	)
 	```
@@ -34,22 +32,18 @@ The `EXP` opcode performs an exponential operation. It reads the integer base `b
         - Do a lookup to exponentiation table for:
 	```
 	(
-	    is_first=1,
 	    is_last=0,
 	    base_limbs,
 	    exponent_lo_hi,
-	    lsb_exponent,
 	    exponentiation_lo_hi,
 	)
 	```
 	- Do a lookup to exponentiation table for:
 	```
 	(
-	    is_first=0,
 	    is_last=1,
 	    base_limbs,
 	    exponent_lo_hi=[2, 0],
-	    lsb_exponent=[2, 0],
 	    base_sq_lo_hi,
 	)
 	```

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -282,3 +282,74 @@ The table below lists all of copy pairs supported in the copy table:
 |        |         |        |           |            |                |                |            |        | $rlcAcc |         |     |           |                 |
 | 1      | 0/1     | 0      | $callID   | Memory     | $memoryAddress | $memoryAddress | $bytesLeft | $value | $rlcAcc | -       | 0/1 | $counter  | $rwcIncLeft     |
 | 0      | 0       | 0/1    | $txID     | TxLog      | $byteIndex \|\| TxLogData \|\| $logID | - | - | $value | $rlcAcc | -       | 0   | $counter  | $rwcIncLeft     |
+
+## Exponentiation Table
+
+Proved by the Exponentiation circuit.
+
+The exponentiation table is a virtual table within the exponentiation circuit assignments. An exponentiation operation `a ^ b == c (mod 2^256)` is broken down into steps that perform the exponentiation by squaring.
+
+The following algorithm is used for exponentiation by squaring:
+```
+Function exp_by_squaring(x, n)
+    if n = 0  then return  1;
+    if n = 1  then return  x;
+    if n is odd:
+	return x * exp_by_squaring(x, n - 1)
+    if n is even:
+	return (exp_by_squaring(x, n / 2))^2
+```
+
+Using the above algorithm, `3 ^ 13 == 1594323 (mod 2^256)` is broken down into the following steps:
+```
+3      * 3   = 9
+9      * 3   = 27
+27     * 27  = 729
+729    * 729 = 531441
+531441 * 3   = 1594323
+```
+
+We assign the above steps to the exponentiation table in the reverse order, so that the first step is `531441 * 3 = 1594323`. From here on, the RHS in the above steps is termed as `intermediate_exponentiation`. We define another term `intermediate_exponent` as a value that starts at the integer exponent of the operation, i.e. `13` in the above case, and reduces down to `2` such that:
+```
+if intermediate_exponent::cur is even:
+	intermediate_exponent::next = intermediate_exponent::cur // 2
+else:
+	intermediate_exponent::next == intermediate_exponent::cur - 1
+```
+
+The exponentiation table consist of 4 columns, namely:
+1. `identifier`: An identifier (currently read-write counter at which the exponentiation table is looked up) to uniquely identify an exponentiation trace.
+2. `is_first`: A boolean value to indicate the first row of the exponentiation trace's table assignments.
+3. `is_last`: A boolean value to indicate the last row of the exponentiation trace's table assignments.
+4. `base_limb`: 64-bit limb representing the integer base of the exponentiation operation.
+5. `exponent_lo_hi`: 128-bit low/high parts of an intermediate value that starts at the integer exponent.
+6. `lsb_exponent`: The least-significant byte in the exponent. For instance, if `exponent == 300`, then `lsb_exponent == 44`.
+7. `exponentiation_lo_hi`: 128-bit low/high parts of an intermediate value that starts at the result of the exponentation operation.
+
+The lookup entry is not a single row in the table, and not every row corresponds to a lookup entry. Instead, a lookup entry is constructed from the first 4 rows in each exponentiation event. For simplicity in the `specs` implementation, we combine all those rows into a single row. But in the `circuits` implementation, we try to lower the number of columns in exchange of increased number of rows.
+
+Depending on the value of the `exponent` within the exponentiation operation, the `EXP` gadget will either:
+1. Do no lookup if `exponent == 0` since `base ^ 0 == 1 (mod 2^256)`
+2. Do no lookup if `exponent == 1` since `base ^ 1 == base (mod 2^256)`
+3. Do 1 lookup to a row if `exponent == 2` since there is a single step in the exponentiation trace, i.e. `base ^ 2 == base * base (mod 2^256)`, implying that `is_first == is_last == 1` for this row.
+4. Do 2 lookups to 2 different rows if `exponent > 2` since there are more than one steps in the exponentiation trace, i.e. a lookup to `is_first == 1 && is_last == 0` and a lookup to `is_first == 0 && is_last == 1`.
+
+Consider `3 ^ 13 == 1594323 (mod 2^256)`. The exponentiation table assignment looks as follows:
+
+| identifier | is_first | is_last | base_limb0 | base_limb1 | base_limb2 | base_limb3 | exponent_lo | exponent_hi | lsb_exponent | exponentiation_lo | exponentiation_hi |
+|------------|----------|---------|------------|------------|------------|------------|-------------|-------------|--------------|-------------------|-------------------|
+| $rwc       | 1        | 0       | 3          | 0          | 0          | 0          | 13          | 0           | 13           | 1594323           | 0                 |
+| $rwc       | 0        | 0       | 3          | 0          | 0          | 0          | 12          | 0           | 12           | 531441            | 0                 |
+| $rwc       | 0        | 0       | 3          | 0          | 0          | 0          | 6           | 0           | 6            | 729               | 0                 |
+| $rwc       | 0        | 0       | 3          | 0          | 0          | 0          | 3           | 0           | 3            | 27                | 0                 |
+| $rwc       | 0        | 1       | 3          | 0          | 0          | 0          | 2           | 0           | 2            | 9                 | 0                 |
+
+For `exponent == 13`, i.e. scenario #4 we do two lookups:
+1. Lookup to first row:
+```
+Row(identifier=rwc, is_first=1, is_last=0, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[13, 0], lsb_exponent=13, exponentiation_lo_hi=[1594323, 0])
+```
+2. Lookup to last row:
+```
+Row(identifier=rwc, is_first=0, is_last=1, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[2, 0], lsb_exponent=2, exponentiation_lo_hi=[9, 0])
+```

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -317,37 +317,38 @@ else:
 	intermediate_exponent::next == intermediate_exponent::cur - 1
 ```
 
-The exponentiation table consist of 4 columns, namely:
-1. `identifier`: An identifier (currently read-write counter at which the exponentiation table is looked up) to uniquely identify an exponentiation trace.
-2. `is_last`: A boolean value to indicate the last row of the exponentiation trace's table assignments.
-3. `base_limb`: 64-bit limb representing the integer base of the exponentiation operation.
-4. `exponent_lo_hi`: 128-bit low/high parts of an intermediate value that starts at the integer exponent.
-5. `exponentiation_lo_hi`: 128-bit low/high parts of an intermediate value that starts at the result of the exponentation operation.
+The exponentiation table consist of 11 columns, namely:
+1. `is_step`: A boolean value to indicate whether or not the row is the start of a step representing the exponentiation trace.
+2. `identifier`: An identifier (currently read-write counter at which the exponentiation table is looked up) to uniquely identify an exponentiation trace.
+3. `is_last`: A boolean value to indicate the last row of the exponentiation trace's table assignments.
+4. `base_limb[i]`: Four 64-bit limbs representing the integer base of the exponentiation operation.
+5. `exponent_lo_hi[i]`: Two 128-bit low/high parts of an intermediate value that starts at the integer exponent.
+6. `exponentiation_lo_hi[i]`: Two 128-bit low/high parts of an intermediate value that starts at the result of the exponentation operation.
 
 The lookup entry is not a single row in the table, and not every row corresponds to a lookup entry. Instead, a lookup entry is constructed from the first 4 rows in each exponentiation event. For simplicity in the `specs` implementation, we combine all those rows into a single row. But in the `circuits` implementation, we try to lower the number of columns in exchange of increased number of rows.
 
-Depending on the value of the `exponent` within the exponentiation operation, the `EXP` gadget will either:
-1. Do no lookup if `exponent == 0` since `base ^ 0 == 1 (mod 2^256)`
-2. Do no lookup if `exponent == 1` since `base ^ 1 == base (mod 2^256)`
-3. Do 1 lookup to a row if `exponent == 2` since there is a single step in the exponentiation trace, i.e. `base ^ 2 == base * base (mod 2^256)`, implying that `is_first == is_last == 1` for this row.
-4. Do 2 lookups to 2 different rows if `exponent > 2` since there are more than one steps in the exponentiation trace, i.e. a lookup to `is_last == 0` and a lookup to `is_last == 1`.
+Depending on the value of the `exponent` within the exponentiation operation, the `EXP` gadget will be handled by one of the below mentioned scenarios:
+1. *Scenario #1* - Do no lookup if `exponent == 0` since `base ^ 0 == 1 (mod 2^256)`
+2. *Scenario #2* Do no lookup if `exponent == 1` since `base ^ 1 == base (mod 2^256)`
+3. *Scenario #3* Do 1 lookup to a row if `exponent == 2` since there is a single step in the exponentiation trace, i.e. `base ^ 2 == base * base (mod 2^256)`, implying that `is_first == is_last == 1` for this row.
+4. *Scenario #4* Do 2 lookups to 2 different rows if `exponent > 2` since there are more than one steps in the exponentiation trace, i.e. a lookup to `is_last == 0` and a lookup to `is_last == 1`.
 
 Consider `3 ^ 13 == 1594323 (mod 2^256)`. The exponentiation table assignment looks as follows:
 
-| identifier | is_last | base_limb0 | base_limb1 | base_limb2 | base_limb3 | exponent_lo | exponent_hi | lsb_exponent | exponentiation_lo | exponentiation_hi |
-|------------|---------|------------|------------|------------|------------|-------------|-------------|--------------|-------------------|-------------------|
-| $rwc       | 0       | 3          | 0          | 0          | 0          | 13          | 0           | 13           | 1594323           | 0                 |
-| $rwc       | 0       | 3          | 0          | 0          | 0          | 12          | 0           | 12           | 531441            | 0                 |
-| $rwc       | 0       | 3          | 0          | 0          | 0          | 6           | 0           | 6            | 729               | 0                 |
-| $rwc       | 0       | 3          | 0          | 0          | 0          | 3           | 0           | 3            | 27                | 0                 |
-| $rwc       | 1       | 3          | 0          | 0          | 0          | 2           | 0           | 2            | 9                 | 0                 |
+| is_step | identifier | is_last | base_limb0 | base_limb1 | base_limb2 | base_limb3 | exponent_lo | exponent_hi | exponentiation_lo | exponentiation_hi |
+|---------|------------|---------|------------|------------|------------|------------|-------------|-------------|-------------------|-------------------|
+| 1       | $rwc       | 0       | 3          | 0          | 0          | 0          | 13          | 0           | 1594323           | 0                 |
+| 1       | $rwc       | 0       | 3          | 0          | 0          | 0          | 12          | 0           | 531441            | 0                 |
+| 1       | $rwc       | 0       | 3          | 0          | 0          | 0          | 6           | 0           | 729               | 0                 |
+| 1       | $rwc       | 0       | 3          | 0          | 0          | 0          | 3           | 0           | 27                | 0                 |
+| 1       | $rwc       | 1       | 3          | 0          | 0          | 0          | 2           | 0           | 9                 | 0                 |
 
-For `exponent == 13`, i.e. scenario #4 we do two lookups:
+For `exponent == 13`, i.e. Scenario #4 we do two lookups:
 1. Lookup to first row:
 ```
-Row(identifier=rwc, is_last=0, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[13, 0], lsb_exponent=13, exponentiation_lo_hi=[1594323, 0])
+Row(is_step=1, identifier=rwc, is_last=0, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[13, 0], exponentiation_lo_hi=[1594323, 0])
 ```
 2. Lookup to last row:
 ```
-Row(identifier=rwc, is_last=1, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[2, 0], lsb_exponent=2, exponentiation_lo_hi=[9, 0])
+Row(is_step=1, identifier=rwc, is_last=1, base_limbs=[3, 0, 0, 0], exponent_lo_hi=[2, 0], exponentiation_lo_hi=[9, 0])
 ```

--- a/src/zkevm_specs/__init__.py
+++ b/src/zkevm_specs/__init__.py
@@ -2,6 +2,7 @@ from . import bytecode
 from . import copy_circuit
 from . import encoding
 from . import evm
+from . import exp_circuit
 from . import opcode
 from . import state
 from . import tx

--- a/src/zkevm_specs/evm/execution/__init__.py
+++ b/src/zkevm_specs/evm/execution/__init__.py
@@ -21,6 +21,7 @@ from .calldatacopy import *
 from .calldataload import *
 from .codecopy import *
 from .codesize import *
+from .exp import *
 from .gas import *
 from .iszero import *
 from .jump import *
@@ -79,6 +80,7 @@ EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.GASPRICE: gasprice,
     ExecutionState.EXTCODECOPY: extcodecopy,
     ExecutionState.EXTCODEHASH: extcodehash,
+    ExecutionState.EXP: exp,
     ExecutionState.LOG: log,
     ExecutionState.CALL_STATICCALL: call_staticcall,
     ExecutionState.ISZERO: iszero,

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -1,0 +1,37 @@
+from ..instruction import Instruction, Transition
+from zkevm_specs.util import FQ, GAS_COST_EXP_PER_BYTE
+
+
+def exp(instruction: Instruction):
+    opcode = instruction.opcode_lookup(True)
+
+    base_rlc = instruction.stack_pop()
+    exponent_rlc = instruction.stack_pop()
+    exponentiation_rlc = instruction.stack_push()
+
+    base_lo, base_hi = instruction.word_to_lo_hi(base_rlc)
+    exponent_lo, exponent_hi = instruction.word_to_lo_hi(exponent_rlc)
+    exponentiation_lo, exponentiation_hi = instruction.word_to_lo_hi(exponentiation_rlc)
+
+    if instruction.is_zero(exponent_rlc) == FQ.one():
+        instruction.constrain_equal(exponentiation_lo, FQ.one())
+        instruction.constrain_zero(exponentiation_hi)
+    elif instruction.is_equal(exponent_rlc, FQ.one()):
+        instruction.constrain_equal(exponentiation_lo, base_lo)
+        instruction.constrain_equal(exponentiation_hi, base_hi)
+    else:
+        base_limbs = instruction.word_to_64s(base_rlc)
+        res_lo, res_hi = instruction.exp_lookup(base_limbs, (exponent_lo, exponent_hi))
+        instruction.constrain_equal(res_lo, exponentiation_lo)
+        instruction.constrain_equal(res_hi, exponentiation_hi)
+
+    exponent_byte_size = instruction.byte_size(exponent_rlc)
+    dynamic_gas_cost = GAS_COST_EXP_PER_BYTE * exponent_byte_size
+
+    instruction.step_state_transition_in_same_context(
+        opcode,
+        program_counter=Transition.delta(1),
+        rw_counter=Transition.delta(3),
+        stack_pointer=Transition.delta(1),
+        dynamic_gas_cost=dynamic_gas_cost,
+    )

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -16,7 +16,7 @@ def exp(instruction: Instruction):
     if instruction.is_zero(exponent_rlc) == FQ.one():
         instruction.constrain_equal(exponentiation_lo, FQ.one())
         instruction.constrain_zero(exponentiation_hi)
-    elif instruction.is_equal(exponent_rlc, FQ.one()):
+    elif instruction.is_equal(exponent_rlc, FQ.one()) == FQ.one():
         instruction.constrain_equal(exponentiation_lo, base_lo)
         instruction.constrain_equal(exponentiation_hi, base_hi)
     else:

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -27,18 +27,17 @@ def exp(instruction: Instruction):
             res_lo, res_hi = instruction.exp_lookup(
                 identifier,
                 FQ.one(),
-                FQ.one(),
                 base_limbs,
                 (exponent_lo, exponent_hi),
             )
         else:
             # lookup to enforce the is_first step
             res_lo, res_hi = instruction.exp_lookup(
-                identifier, FQ.one(), FQ.zero(), base_limbs, (exponent_lo, exponent_hi)
+                identifier, FQ.zero(), base_limbs, (exponent_lo, exponent_hi)
             )
             # lookup to enforce the is_last step
             int_res_lo, int_res_hi = instruction.exp_lookup(
-                identifier, FQ.zero(), FQ.one(), base_limbs, (FQ(2), FQ.zero())
+                identifier, FQ.one(), base_limbs, (FQ(2), FQ.zero())
             )
             # intermediary result should be base^2
             int_res = instruction.rlc_encode(

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -21,19 +21,24 @@ def exp(instruction: Instruction):
         instruction.constrain_equal(exponentiation_hi, base_hi)
     else:
         base_limbs = instruction.word_to_64s(base_rlc)
+        identifier = FQ(instruction.curr.rw_counter + instruction.rw_counter_offset)
         if instruction.is_equal(exponent_rlc, FQ(2)) == FQ.one():
             # lookup to enforce the is_first and is_last step
             res_lo, res_hi = instruction.exp_lookup(
-                FQ.one(), FQ.one(), base_limbs, (exponent_lo, exponent_hi)
+                identifier,
+                FQ.one(),
+                FQ.one(),
+                base_limbs,
+                (exponent_lo, exponent_hi),
             )
         else:
             # lookup to enforce the is_first step
             res_lo, res_hi = instruction.exp_lookup(
-                FQ.one(), FQ.zero(), base_limbs, (exponent_lo, exponent_hi)
+                identifier, FQ.one(), FQ.zero(), base_limbs, (exponent_lo, exponent_hi)
             )
             # lookup to enforce the is_last step
             int_res_lo, int_res_hi = instruction.exp_lookup(
-                FQ.zero(), FQ.one(), base_limbs, (FQ(2), FQ.zero())
+                identifier, FQ.zero(), FQ.one(), base_limbs, (FQ(2), FQ.zero())
             )
             # intermediary result should be base^2
             int_res = instruction.rlc_encode(

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1063,12 +1063,9 @@ class Instruction:
     def exp_lookup(
         self,
         identifier: Expression,
-        is_first: Expression,
         is_last: Expression,
         base_limbs: Tuple[Expression, ...],
         exponent_lo_hi: Tuple[Expression, Expression],
     ) -> Tuple[FQ, FQ]:
-        exp_table_row = self.tables.exp_lookup(
-            identifier, is_first, is_last, base_limbs, exponent_lo_hi
-        )
+        exp_table_row = self.tables.exp_lookup(identifier, is_last, base_limbs, exponent_lo_hi)
         return exp_table_row.exponentiation_lo, exp_table_row.exponentiation_hi

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1062,10 +1062,13 @@ class Instruction:
 
     def exp_lookup(
         self,
+        identifier: Expression,
         is_first: Expression,
         is_last: Expression,
         base_limbs: Tuple[Expression, ...],
         exponent_lo_hi: Tuple[Expression, Expression],
     ) -> Tuple[FQ, FQ]:
-        exp_table_row = self.tables.exp_lookup(is_first, is_last, base_limbs, exponent_lo_hi)
+        exp_table_row = self.tables.exp_lookup(
+            identifier, is_first, is_last, base_limbs, exponent_lo_hi
+        )
         return exp_table_row.exponentiation_lo, exp_table_row.exponentiation_hi

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -1062,8 +1062,10 @@ class Instruction:
 
     def exp_lookup(
         self,
+        is_first: Expression,
+        is_last: Expression,
         base_limbs: Tuple[Expression, ...],
         exponent_lo_hi: Tuple[Expression, Expression],
     ) -> Tuple[FQ, FQ]:
-        exp_table_row = self.tables.exp_lookup(base_limbs, exponent_lo_hi)
+        exp_table_row = self.tables.exp_lookup(is_first, is_last, base_limbs, exponent_lo_hi)
         return exp_table_row.exponentiation_lo, exp_table_row.exponentiation_hi

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -421,6 +421,10 @@ class Instruction:
         assert len(word.le_bytes) == 32, "Expected word to contain 32 bytes"
         return tuple(self.bytes_to_fq(word.le_bytes[8 * i : 8 * (i + 1)]) for i in range(4))
 
+    def byte_size(self, word: RLC) -> FQ:
+        assert len(word.le_bytes) == 32, "Expected word to contain 32 bytes"
+        return FQ(len(bytearray(word.le_bytes).rstrip(b"\x00")))
+
     def bytes_to_fq(self, value: bytes, constrained=False) -> FQ:
         assert len(value) <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
 
@@ -1055,3 +1059,11 @@ class Instruction:
 
     def keccak_lookup(self, length: Expression, value_rlc: Expression) -> FQ:
         return self.tables.keccak_lookup(length, value_rlc).output
+
+    def exp_lookup(
+        self,
+        base_limbs: Tuple[Expression, ...],
+        exponent_lo_hi: Tuple[Expression, Expression],
+    ) -> Tuple[FQ, FQ]:
+        exp_table_row = self.tables.exp_lookup(base_limbs, exponent_lo_hi)
+        return exp_table_row.exponentiation_lo, exp_table_row.exponentiation_hi

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -472,15 +472,14 @@ class KeccakTableRow(TableRow):
 class ExpCircuitRow(TableRow):
     q_step: FQ
     is_pad: FQ
-    # division of intermediate exponent by 2
-    remainder: FQ
-    quotient: RLC
+    is_odd: FQ
     # columns from the exponentiation table
     identifier: FQ  # (block_no || rw_counter)
     is_first: FQ
     is_last: FQ
     base: RLC
     intermediate_exponent: RLC
+    lsb_intermediate_exponent: FQ
     intermediate_exponentiation: RLC
     # columns from the MulGadget
     a: RLC
@@ -500,6 +499,7 @@ class ExpTableRow(TableRow):
     base_limb3: FQ
     exponent_lo: FQ
     exponent_hi: FQ
+    lsb_exponent: FQ
     exponentiation_lo: FQ
     exponentiation_hi: FQ
 
@@ -587,6 +587,7 @@ class Tables:
                     base_limb3=base_limbs[3],
                     exponent_lo=intermediate_exponent_lo_hi[0],
                     exponent_hi=intermediate_exponent_lo_hi[1],
+                    lsb_exponent=row.lsb_intermediate_exponent,
                     exponentiation_lo=intermediate_exponentiation_lo_hi[0],
                     exponentiation_hi=intermediate_exponentiation_lo_hi[1],
                 )

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -475,6 +475,7 @@ class ExpCircuitRow(TableRow):
     remainder: FQ
     quotient: RLC
     # columns from the exponentiation table
+    identifier: FQ  # (block_no || rw_counter)
     is_first: FQ
     is_last: FQ
     base: RLC
@@ -489,6 +490,7 @@ class ExpCircuitRow(TableRow):
 
 @dataclass(frozen=True)
 class ExpTableRow(TableRow):
+    identifier: FQ
     is_first: FQ
     is_last: FQ
     base_limb0: FQ
@@ -573,6 +575,7 @@ class Tables:
             intermediate_exponentiation_lo_hi = word_to_lo_hi(row.intermediate_exponentiation)
             rows.append(
                 ExpTableRow(
+                    identifier=row.identifier,
                     is_first=row.is_first,
                     is_last=row.is_last,
                     base_limb0=base_limbs[0],
@@ -702,12 +705,14 @@ class Tables:
 
     def exp_lookup(
         self,
+        identifier: Expression,
         is_first: Expression,
         is_last: Expression,
         base_limbs: Tuple[Expression, ...],
         exponent: Tuple[Expression, Expression],
     ):
         query = {
+            "identifier": identifier.expr(),
             "is_first": is_first.expr(),
             "is_last": is_last.expr(),
             "base_limb0": base_limbs[0].expr(),

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -471,14 +471,12 @@ class KeccakTableRow(TableRow):
 @dataclass
 class ExpCircuitRow(TableRow):
     q_step: FQ
-    idx: FQ
-    is_last: FQ
-    is_pad: FQ
     # division of intermediate exponent by 2
     remainder: FQ
     quotient: RLC
     # columns from the exponentiation table
     is_first: FQ
+    is_last: FQ
     base: RLC
     intermediate_exponent: RLC
     intermediate_exponentiation: RLC
@@ -492,6 +490,7 @@ class ExpCircuitRow(TableRow):
 @dataclass(frozen=True)
 class ExpTableRow(TableRow):
     is_first: FQ
+    is_last: FQ
     base_limb0: FQ
     base_limb1: FQ
     base_limb2: FQ
@@ -575,6 +574,7 @@ class Tables:
             rows.append(
                 ExpTableRow(
                     is_first=row.is_first,
+                    is_last=row.is_last,
                     base_limb0=base_limbs[0],
                     base_limb1=base_limbs[1],
                     base_limb2=base_limbs[2],
@@ -702,11 +702,14 @@ class Tables:
 
     def exp_lookup(
         self,
+        is_first: Expression,
+        is_last: Expression,
         base_limbs: Tuple[Expression, ...],
         exponent: Tuple[Expression, Expression],
     ):
         query = {
-            "is_first": FQ.one(),
+            "is_first": is_first.expr(),
+            "is_last": is_last.expr(),
             "base_limb0": base_limbs[0].expr(),
             "base_limb1": base_limbs[1].expr(),
             "base_limb2": base_limbs[2].expr(),

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field, fields
 
 from .opcode import constant_gas_cost_pairs
 
-from ..util import Expression, FQ
+from ..util import Expression, FQ, RLC, word_to_lo_hi, word_to_64s
 from .execution_state import ExecutionState
 
 
@@ -476,27 +476,14 @@ class ExpCircuitRow(TableRow):
     remainder: FQ
     # columns from the exponentiation table
     is_first: FQ
-    base_limb0: FQ
-    base_limb1: FQ
-    base_limb2: FQ
-    base_limb3: FQ
-    intermediate_exponent_lo: FQ
-    intermediate_exponent_hi: FQ
-    intermediate_exponentiation_lo: FQ
-    intermediate_exponentiation_hi: FQ
+    base: RLC
+    intermediate_exponent: RLC
+    intermediate_exponentiation: RLC
     # columns from the MulGadget
-    a_limb0: FQ
-    a_limb1: FQ
-    a_limb2: FQ
-    a_limb3: FQ
-    b_limb0: FQ
-    b_limb1: FQ
-    b_limb2: FQ
-    b_limb3: FQ
-    c_lo: FQ
-    c_hi: FQ
-    d_lo: FQ
-    d_hi: FQ
+    a: RLC
+    b: RLC
+    c: RLC
+    d: RLC
 
 
 @dataclass(frozen=True)
@@ -579,17 +566,20 @@ class Tables:
     def _convert_exp_circuit_to_table(self, exp_circuit: Sequence[ExpCircuitRow]):
         rows: List[ExpTableRow] = []
         for i, row in enumerate(exp_circuit):
+            base_limbs = word_to_64s(row.base)
+            intermediate_exponent_lo_hi = word_to_lo_hi(row.intermediate_exponent)
+            intermediate_exponentiation_lo_hi = word_to_lo_hi(row.intermediate_exponentiation)
             rows.append(
                 ExpTableRow(
                     is_first=row.is_first,
-                    base_limb0=row.base_limb0,
-                    base_limb1=row.base_limb1,
-                    base_limb2=row.base_limb2,
-                    base_limb3=row.base_limb3,
-                    exponent_lo=row.intermediate_exponent_lo,
-                    exponent_hi=row.intermediate_exponent_hi,
-                    exponentiation_lo=row.intermediate_exponentiation_lo,
-                    exponentiation_hi=row.intermediate_exponentiation_hi,
+                    base_limb0=base_limbs[0],
+                    base_limb1=base_limbs[1],
+                    base_limb2=base_limbs[2],
+                    base_limb3=base_limbs[3],
+                    exponent_lo=intermediate_exponent_lo_hi[0],
+                    exponent_hi=intermediate_exponent_lo_hi[1],
+                    exponentiation_lo=intermediate_exponentiation_lo_hi[0],
+                    exponentiation_hi=intermediate_exponentiation_lo_hi[1],
                 )
             )
         return set(rows)

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -476,15 +476,27 @@ class ExpCircuitRow(TableRow):
     remainder: FQ
     # columns from the exponentiation table
     is_first: FQ
-    base_limb: FQ
-    intermediate_exponent_lo_hi: FQ
-    intermediate_exponentiation_lo_hi: FQ
+    base_limb0: FQ
+    base_limb1: FQ
+    base_limb2: FQ
+    base_limb3: FQ
+    intermediate_exponent_lo: FQ
+    intermediate_exponent_hi: FQ
+    intermediate_exponentiation_lo: FQ
+    intermediate_exponentiation_hi: FQ
     # columns from the MulGadget
-    col0: FQ
-    col1: FQ
-    col2: FQ
-    col3: FQ
-    col4: FQ
+    a_limb0: FQ
+    a_limb1: FQ
+    a_limb2: FQ
+    a_limb3: FQ
+    b_limb0: FQ
+    b_limb1: FQ
+    b_limb2: FQ
+    b_limb3: FQ
+    c_lo: FQ
+    c_hi: FQ
+    d_lo: FQ
+    d_hi: FQ
 
 
 @dataclass(frozen=True)
@@ -566,7 +578,20 @@ class Tables:
 
     def _convert_exp_circuit_to_table(self, exp_circuit: Sequence[ExpCircuitRow]):
         rows: List[ExpTableRow] = []
-        # TODO(rohit): unimplemented
+        for i, row in enumerate(exp_circuit):
+            rows.append(
+                ExpTableRow(
+                    is_first=row.is_first,
+                    base_limb0=row.base_limb0,
+                    base_limb1=row.base_limb1,
+                    base_limb2=row.base_limb2,
+                    base_limb3=row.base_limb3,
+                    exponent_lo=row.intermediate_exponent_lo,
+                    exponent_hi=row.intermediate_exponent_hi,
+                    exponentiation_lo=row.intermediate_exponentiation_lo,
+                    exponentiation_hi=row.intermediate_exponentiation_hi,
+                )
+            )
         return set(rows)
 
     def fixed_lookup(

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -473,6 +473,7 @@ class ExpCircuitRow(TableRow):
     q_step: FQ
     idx: FQ
     is_last: FQ
+    is_pad: FQ
     # division of intermediate exponent by 2
     remainder: FQ
     quotient: RLC

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -473,7 +473,9 @@ class ExpCircuitRow(TableRow):
     q_step: FQ
     idx: FQ
     is_last: FQ
+    # division of intermediate exponent by 2
     remainder: FQ
+    quotient: RLC
     # columns from the exponentiation table
     is_first: FQ
     base: RLC

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -566,7 +566,7 @@ class Tables:
 
     def _convert_exp_circuit_to_table(self, exp_circuit: Sequence[ExpCircuitRow]):
         rows: List[ExpTableRow] = []
-        # TODO(rohit): implement
+        # TODO(rohit): unimplemented
         return set(rows)
 
     def fixed_lookup(

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -471,6 +471,7 @@ class KeccakTableRow(TableRow):
 @dataclass
 class ExpCircuitRow(TableRow):
     q_step: FQ
+    is_pad: FQ
     # division of intermediate exponent by 2
     remainder: FQ
     quotient: RLC
@@ -570,6 +571,8 @@ class Tables:
     def _convert_exp_circuit_to_table(self, exp_circuit: Sequence[ExpCircuitRow]):
         rows: List[ExpTableRow] = []
         for i, row in enumerate(exp_circuit):
+            if row.is_pad == FQ.one():
+                continue
             base_limbs = word_to_64s(row.base)
             intermediate_exponent_lo_hi = word_to_lo_hi(row.intermediate_exponent)
             intermediate_exponentiation_lo_hi = word_to_lo_hi(row.intermediate_exponentiation)

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -801,86 +801,28 @@ class ExpCircuit:
                 is_last=FQ(is_last),
                 remainder=FQ(remainder),
                 is_first=FQ(is_first),
-                base_limb=base_limbs[0],
-                intermediate_exponent_lo_hi=exponent_lo_hi[0],
-                intermediate_exponentiation_lo_hi=exponentiation_lo_hi[0],
-                col0=a_limbs[0],
-                col1=a_limbs[1],
-                col2=a_limbs[2],
-                col3=a_limbs[3],
-                col4=FQ.zero(),
+                base_limb0=base_limbs[0],
+                base_limb1=base_limbs[1],
+                base_limb2=base_limbs[2],
+                base_limb3=base_limbs[3],
+                intermediate_exponent_lo=exponent_lo_hi[0],
+                intermediate_exponent_hi=exponent_lo_hi[1],
+                intermediate_exponentiation_lo=exponentiation_lo_hi[0],
+                intermediate_exponentiation_hi=exponentiation_lo_hi[1],
+                a_limb0=a_limbs[0],
+                a_limb1=a_limbs[1],
+                a_limb2=a_limbs[2],
+                a_limb3=a_limbs[3],
+                b_limb0=b_limbs[0],
+                b_limb1=b_limbs[1],
+                b_limb2=b_limbs[2],
+                b_limb3=b_limbs[3],
+                c_lo=FQ.zero(),
+                c_hi=FQ.zero(),
+                d_lo=d_lo_hi[0],
+                d_hi=d_lo_hi[1],
             )
         )
-        self.rows.append(
-            ExpCircuitRow(
-                q_step=FQ.zero(),
-                idx=FQ.zero(),
-                is_last=FQ.zero(),
-                remainder=FQ.zero(),
-                is_first=FQ.zero(),
-                base_limb=base_limbs[1],
-                intermediate_exponent_lo_hi=exponent_lo_hi[1],
-                intermediate_exponentiation_lo_hi=exponentiation_lo_hi[1],
-                col0=b_limbs[0],
-                col1=b_limbs[0],
-                col2=b_limbs[0],
-                col3=b_limbs[0],
-                col4=FQ.zero(),
-            )
-        )
-        self.rows.append(
-            ExpCircuitRow(
-                q_step=FQ.zero(),
-                idx=FQ.zero(),
-                is_last=FQ.zero(),
-                remainder=FQ.zero(),
-                is_first=FQ.zero(),
-                base_limb=base_limbs[2],
-                intermediate_exponent_lo_hi=FQ.zero(),
-                intermediate_exponentiation_lo_hi=FQ.zero(),
-                col0=FQ.zero(),
-                col1=FQ.zero(),
-                col2=d_lo_hi[0],
-                col3=d_lo_hi[1],
-                col4=FQ.zero(),
-            )
-        )
-        self.rows.append(
-            ExpCircuitRow(
-                q_step=FQ.zero(),
-                idx=FQ.zero(),
-                is_last=FQ.zero(),
-                remainder=FQ.zero(),
-                is_first=FQ.zero(),
-                base_limb=base_limbs[3],
-                intermediate_exponent_lo_hi=FQ.zero(),
-                intermediate_exponentiation_lo_hi=FQ.zero(),
-                col0=FQ.zero(),
-                col1=FQ.zero(),
-                col2=FQ.zero(),
-                col3=FQ.zero(),
-                col4=FQ.zero(),
-            )
-        )
-        # pad empty rows to make up for 7 rows per step.
-        for _ in range(3):
-            self.rows.append(
-                ExpCircuitRow(
-                    q_step=FQ.zero(),
-                    idx=FQ.zero(),
-                    is_last=FQ.zero(),
-                    remainder=FQ.zero(),
-                    is_first=FQ.zero(),
-                    base_limb=FQ.zero(),
-                    intermediate_exponent_lo_hi=FQ.zero(),
-                    intermediate_exponentiation_lo_hi=FQ.zero(),
-                    col0=FQ.zero(),
-                    col1=FQ.zero(),
-                    col2=FQ.zero(),
-                    col3=FQ.zero(),
-                    col4=FQ.zero(),
-                )
-            )
 
 
 class CopyCircuit:

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -721,6 +721,7 @@ class ExpCircuit:
         exponentiation = self._exp_by_squaring(base, exponent, steps)
         steps.reverse()
         self._append_steps(base, exponent, exponentiation, steps, randomness, identifier)
+        self._append_padding_row(identifier)
         return self
 
     def _exp_by_squaring(self, base: int, exponent: int, steps: List[Tuple[int, int, int]]):
@@ -779,6 +780,26 @@ class ExpCircuit:
                 # exponent is odd
                 exponent = exponent - 1
 
+    def _append_padding_row(self, identifier: IntOrFQ):
+        self.rows.append(
+            ExpCircuitRow(
+                q_step=FQ.zero(),
+                remainder=FQ.zero(),
+                quotient=RLC(0),
+                identifier=FQ(identifier),
+                is_first=FQ.zero(),
+                is_last=FQ.zero(),
+                base=RLC(0),
+                intermediate_exponent=RLC(0),
+                intermediate_exponentiation=RLC(0),
+                a=RLC(0),
+                b=RLC(0),
+                c=RLC(0),
+                d=RLC(0),
+                is_pad=FQ.one(),
+            )
+        )
+
     def _append_step(
         self,
         identifier: IntOrFQ,
@@ -809,6 +830,7 @@ class ExpCircuit:
                 b=b,
                 c=c,
                 d=d,
+                is_pad=FQ.zero(),
             )
         )
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -762,8 +762,6 @@ class ExpCircuit:
             self._append_step(
                 identifier,
                 FQ(1 if i == len(steps) - 1 else 0),
-                RLC(quotient, randomness, n_bytes=32),
-                FQ(is_odd),
                 base_rlc,
                 exponent_rlc,
                 RLC(d, randomness, n_bytes=32),
@@ -771,6 +769,8 @@ class ExpCircuit:
                 RLC(b, randomness, n_bytes=32),
                 RLC(0, randomness, n_bytes=32),
                 RLC(d, randomness, n_bytes=32),
+                RLC(quotient, randomness, n_bytes=32),
+                RLC(is_odd, randomness, n_bytes=32),
             )
             if is_odd == 0:
                 # exponent is even
@@ -782,10 +782,8 @@ class ExpCircuit:
     def _append_padding_row(self, identifier: IntOrFQ):
         self.rows.append(
             ExpCircuitRow(
-                q_step=FQ.zero(),
-                is_pad=FQ.one(),
-                quotient=RLC(0),
-                is_odd=FQ.zero(),
+                q_usable=FQ.zero(),
+                is_step=FQ.zero(),
                 identifier=FQ(identifier),
                 is_last=FQ.zero(),
                 base=RLC(0),
@@ -795,6 +793,8 @@ class ExpCircuit:
                 b=RLC(0),
                 c=RLC(0),
                 d=RLC(0),
+                q=RLC(0),
+                r=RLC(0),
             )
         )
 
@@ -802,8 +802,6 @@ class ExpCircuit:
         self,
         identifier: IntOrFQ,
         is_last: IntOrFQ,
-        quotient: RLC,
-        is_odd: IntOrFQ,
         base: RLC,
         exponent: RLC,
         exponentiation: RLC,
@@ -811,13 +809,13 @@ class ExpCircuit:
         b: RLC,
         c: RLC,
         d: RLC,
+        quotient: RLC,
+        remainder: RLC,
     ):
         self.rows.append(
             ExpCircuitRow(
-                q_step=FQ.one(),
-                is_pad=FQ.zero(),
-                quotient=quotient,
-                is_odd=FQ(is_odd),
+                q_usable=FQ.one(),
+                is_step=FQ.one(),
                 identifier=FQ(identifier),
                 is_last=FQ(is_last),
                 base=base,
@@ -827,6 +825,8 @@ class ExpCircuit:
                 b=b,
                 c=c,
                 d=d,
+                q=quotient,
+                r=remainder,
             )
         )
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -754,13 +754,14 @@ class ExpCircuit:
             # multiplication gadget
             a, b, d = step[0], step[1], step[2]
             # exp table
-            remainder = exponent % 2
+            quotient, remainder = divmod(exponent, 2)
             exponent_rlc = RLC(exponent, randomness, n_bytes=32)
             self._append_step(
                 FQ(idx),
                 FQ(1 if idx == 0 else 0),
                 FQ(1 if idx == len(steps) - 1 else 0),
                 FQ(remainder),
+                RLC(quotient, randomness, n_bytes=32),
                 base_rlc,
                 exponent_rlc,
                 RLC(d, randomness, n_bytes=32),
@@ -782,6 +783,7 @@ class ExpCircuit:
         is_first: IntOrFQ,
         is_last: IntOrFQ,
         remainder: IntOrFQ,
+        quotient: RLC,
         base: RLC,
         exponent: RLC,
         exponentiation: RLC,
@@ -796,6 +798,7 @@ class ExpCircuit:
                 idx=FQ(idx),
                 is_last=FQ(is_last),
                 remainder=FQ(remainder),
+                quotient=quotient,
                 is_first=FQ(is_first),
                 base=base,
                 intermediate_exponent=exponent,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -862,6 +862,25 @@ class ExpCircuit:
                 col4=FQ.zero(),
             )
         )
+        # pad empty rows to make up for 7 rows per step.
+        for _ in range(3):
+            self.rows.append(
+                ExpCircuitRow(
+                    q_step=FQ.zero(),
+                    idx=FQ.zero(),
+                    is_last=FQ.zero(),
+                    remainder=FQ.zero(),
+                    is_first=FQ.zero(),
+                    base_limb=FQ.zero(),
+                    intermediate_exponent_lo_hi=FQ.zero(),
+                    intermediate_exponentiation_lo_hi=FQ.zero(),
+                    col0=FQ.zero(),
+                    col1=FQ.zero(),
+                    col2=FQ.zero(),
+                    col3=FQ.zero(),
+                    col4=FQ.zero(),
+                )
+            )
 
 
 class CopyCircuit:

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -757,16 +757,15 @@ class ExpCircuit:
             # multiplication gadget
             a, b, d = step[0], step[1], step[2]
             # exp table
-            _, is_odd = divmod(exponent, 2)
+            quotient, is_odd = divmod(exponent, 2)
             exponent_rlc = RLC(exponent, randomness, n_bytes=32)
             self._append_step(
                 identifier,
-                FQ(1 if i == 0 else 0),
                 FQ(1 if i == len(steps) - 1 else 0),
+                RLC(quotient, randomness, n_bytes=32),
                 FQ(is_odd),
                 base_rlc,
                 exponent_rlc,
-                (exponent & 0b11111111),
                 RLC(d, randomness, n_bytes=32),
                 RLC(a, randomness, n_bytes=32),
                 RLC(b, randomness, n_bytes=32),
@@ -785,14 +784,13 @@ class ExpCircuit:
             ExpCircuitRow(
                 q_step=FQ.zero(),
                 is_pad=FQ.one(),
+                quotient=RLC(0),
                 is_odd=FQ.zero(),
                 identifier=FQ(identifier),
-                is_first=FQ.zero(),
                 is_last=FQ.zero(),
                 base=RLC(0),
-                intermediate_exponent=RLC(0),
-                lsb_intermediate_exponent=FQ.zero(),
-                intermediate_exponentiation=RLC(0),
+                exponent=RLC(0),
+                exponentiation=RLC(0),
                 a=RLC(0),
                 b=RLC(0),
                 c=RLC(0),
@@ -803,12 +801,11 @@ class ExpCircuit:
     def _append_step(
         self,
         identifier: IntOrFQ,
-        is_first: IntOrFQ,
         is_last: IntOrFQ,
+        quotient: RLC,
         is_odd: IntOrFQ,
         base: RLC,
         exponent: RLC,
-        lsb_exponent: IntOrFQ,
         exponentiation: RLC,
         a: RLC,
         b: RLC,
@@ -819,14 +816,13 @@ class ExpCircuit:
             ExpCircuitRow(
                 q_step=FQ.one(),
                 is_pad=FQ.zero(),
+                quotient=quotient,
                 is_odd=FQ(is_odd),
                 identifier=FQ(identifier),
-                is_first=FQ(is_first),
                 is_last=FQ(is_last),
                 base=base,
-                intermediate_exponent=exponent,
-                lsb_intermediate_exponent=FQ(lsb_exponent),
-                intermediate_exponentiation=exponentiation,
+                exponent=exponent,
+                exponentiation=exponentiation,
                 a=a,
                 b=b,
                 c=c,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -717,33 +717,10 @@ class ExpCircuit:
         return self.rows + self.pad_rows
 
     def add_event(self, base: int, exponent: int, randomness: FQ):
-        idx = FQ.one() if not self.rows else self.rows[-1].idx + 1
         steps: List[Tuple[int, int, int]] = []
         exponentiation = self._exp_by_squaring(base, exponent, steps)
         steps.reverse()
-        self._append_steps(idx, base, exponent, exponentiation, steps, randomness)
-        return self
-
-    def append_padding_rows(self):
-        idx = FQ.one() if not self.rows else self.rows[-1].idx + 1
-        self.pad_rows.append(
-            ExpCircuitRow(
-                q_step=FQ.zero(),
-                idx=FQ(idx),
-                is_last=FQ.zero(),
-                is_pad=FQ.one(),
-                remainder=FQ.zero(),
-                quotient=RLC(0),
-                is_first=FQ.zero(),
-                base=RLC(0),
-                intermediate_exponent=RLC(0),
-                intermediate_exponentiation=RLC(0),
-                a=RLC(0),
-                b=RLC(0),
-                c=RLC(0),
-                d=RLC(0),
-            )
-        )
+        self._append_steps(base, exponent, exponentiation, steps, randomness)
         return self
 
     def _exp_by_squaring(self, base: int, exponent: int, steps: List[Tuple[int, int, int]]):
@@ -767,7 +744,6 @@ class ExpCircuit:
 
     def _append_steps(
         self,
-        idx: IntOrFQ,
         base: int,
         exponent: int,
         exponentiation: int,
@@ -782,7 +758,6 @@ class ExpCircuit:
             quotient, remainder = divmod(exponent, 2)
             exponent_rlc = RLC(exponent, randomness, n_bytes=32)
             self._append_step(
-                FQ(idx),
                 FQ(1 if i == 0 else 0),
                 FQ(1 if i == len(steps) - 1 else 0),
                 FQ(remainder),
@@ -804,7 +779,6 @@ class ExpCircuit:
 
     def _append_step(
         self,
-        idx: IntOrFQ,
         is_first: IntOrFQ,
         is_last: IntOrFQ,
         remainder: IntOrFQ,
@@ -820,12 +794,10 @@ class ExpCircuit:
         self.rows.append(
             ExpCircuitRow(
                 q_step=FQ.one(),
-                idx=FQ(idx),
-                is_last=FQ(is_last),
-                is_pad=FQ.zero(),
                 remainder=FQ(remainder),
                 quotient=quotient,
                 is_first=FQ(is_first),
+                is_last=FQ(is_last),
                 base=base,
                 intermediate_exponent=exponent,
                 intermediate_exponentiation=exponentiation,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -716,11 +716,11 @@ class ExpCircuit:
     def table(self) -> Sequence[ExpCircuitRow]:
         return self.rows + self.pad_rows
 
-    def add_event(self, base: int, exponent: int, randomness: FQ):
+    def add_event(self, base: int, exponent: int, randomness: FQ, identifier: IntOrFQ):
         steps: List[Tuple[int, int, int]] = []
         exponentiation = self._exp_by_squaring(base, exponent, steps)
         steps.reverse()
-        self._append_steps(base, exponent, exponentiation, steps, randomness)
+        self._append_steps(base, exponent, exponentiation, steps, randomness, identifier)
         return self
 
     def _exp_by_squaring(self, base: int, exponent: int, steps: List[Tuple[int, int, int]]):
@@ -749,6 +749,7 @@ class ExpCircuit:
         exponentiation: int,
         steps: List[Tuple[int, int, int]],
         randomness: FQ,
+        identifier: IntOrFQ,
     ):
         base_rlc = RLC(base, randomness, n_bytes=32)
         for i, step in enumerate(steps):
@@ -758,6 +759,7 @@ class ExpCircuit:
             quotient, remainder = divmod(exponent, 2)
             exponent_rlc = RLC(exponent, randomness, n_bytes=32)
             self._append_step(
+                identifier,
                 FQ(1 if i == 0 else 0),
                 FQ(1 if i == len(steps) - 1 else 0),
                 FQ(remainder),
@@ -779,6 +781,7 @@ class ExpCircuit:
 
     def _append_step(
         self,
+        identifier: IntOrFQ,
         is_first: IntOrFQ,
         is_last: IntOrFQ,
         remainder: IntOrFQ,
@@ -796,6 +799,7 @@ class ExpCircuit:
                 q_step=FQ.one(),
                 remainder=FQ(remainder),
                 quotient=quotient,
+                identifier=FQ(identifier),
                 is_first=FQ(is_first),
                 is_last=FQ(is_last),
                 base=base,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -757,23 +757,23 @@ class ExpCircuit:
             # multiplication gadget
             a, b, d = step[0], step[1], step[2]
             # exp table
-            quotient, remainder = divmod(exponent, 2)
+            _, is_odd = divmod(exponent, 2)
             exponent_rlc = RLC(exponent, randomness, n_bytes=32)
             self._append_step(
                 identifier,
                 FQ(1 if i == 0 else 0),
                 FQ(1 if i == len(steps) - 1 else 0),
-                FQ(remainder),
-                RLC(quotient, randomness, n_bytes=32),
+                FQ(is_odd),
                 base_rlc,
                 exponent_rlc,
+                (exponent & 0b11111111),
                 RLC(d, randomness, n_bytes=32),
                 RLC(a, randomness, n_bytes=32),
                 RLC(b, randomness, n_bytes=32),
                 RLC(0, randomness, n_bytes=32),
                 RLC(d, randomness, n_bytes=32),
             )
-            if remainder == 0:
+            if is_odd == 0:
                 # exponent is even
                 exponent = exponent // 2
             else:
@@ -784,19 +784,19 @@ class ExpCircuit:
         self.rows.append(
             ExpCircuitRow(
                 q_step=FQ.zero(),
-                remainder=FQ.zero(),
-                quotient=RLC(0),
+                is_pad=FQ.one(),
+                is_odd=FQ.zero(),
                 identifier=FQ(identifier),
                 is_first=FQ.zero(),
                 is_last=FQ.zero(),
                 base=RLC(0),
                 intermediate_exponent=RLC(0),
+                lsb_intermediate_exponent=FQ.zero(),
                 intermediate_exponentiation=RLC(0),
                 a=RLC(0),
                 b=RLC(0),
                 c=RLC(0),
                 d=RLC(0),
-                is_pad=FQ.one(),
             )
         )
 
@@ -805,10 +805,10 @@ class ExpCircuit:
         identifier: IntOrFQ,
         is_first: IntOrFQ,
         is_last: IntOrFQ,
-        remainder: IntOrFQ,
-        quotient: RLC,
+        is_odd: IntOrFQ,
         base: RLC,
         exponent: RLC,
+        lsb_exponent: IntOrFQ,
         exponentiation: RLC,
         a: RLC,
         b: RLC,
@@ -818,19 +818,19 @@ class ExpCircuit:
         self.rows.append(
             ExpCircuitRow(
                 q_step=FQ.one(),
-                remainder=FQ(remainder),
-                quotient=quotient,
+                is_pad=FQ.zero(),
+                is_odd=FQ(is_odd),
                 identifier=FQ(identifier),
                 is_first=FQ(is_first),
                 is_last=FQ(is_last),
                 base=base,
                 intermediate_exponent=exponent,
+                lsb_intermediate_exponent=FQ(lsb_exponent),
                 intermediate_exponentiation=exponentiation,
                 a=a,
                 b=b,
                 c=c,
                 d=d,
-                is_pad=FQ.zero(),
             )
         )
 

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -5,12 +5,69 @@ from .evm import (
 )
 from .util import (
     ConstraintSystem,
+    FQ,
+    lo_hi_to_64s,
 )
 
 
 def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
-    # TODO(rohit): implement
-    print("hello")
+    # for every step except the last
+    with cs.condition(rows[0].q_step * (1 - rows[0].is_last)) as cs:
+        # base limbs are the same across rows.
+        cs.constrain_equal(rows[0].base_limb0, rows[1].base_limb0)
+        cs.constrain_equal(rows[0].base_limb1, rows[1].base_limb1)
+        cs.constrain_equal(rows[0].base_limb2, rows[1].base_limb2)
+        cs.constrain_equal(rows[0].base_limb3, rows[1].base_limb3)
+        # multiplication result from the "next" row `d` must be used as
+        # the first multiplicand in the "cur" row `a`
+        d_next_limbs = lo_hi_to_64s((rows[1].d_lo, rows[1].d_hi))
+        cs.constrain_equal(rows[0].a_limb0, d_next_limbs[0])
+        cs.constrain_equal(rows[0].a_limb1, d_next_limbs[1])
+        cs.constrain_equal(rows[0].a_limb2, d_next_limbs[2])
+        cs.constrain_equal(rows[0].a_limb3, d_next_limbs[3])
+
+    # for the last row, we have: base * base == base^2
+    with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
+        # a == base (all limbs)
+        cs.constrain_equal(rows[0].base_limb0, rows[0].a_limb0)
+        cs.constrain_equal(rows[0].base_limb1, rows[0].a_limb1)
+        cs.constrain_equal(rows[0].base_limb2, rows[0].a_limb2)
+        cs.constrain_equal(rows[0].base_limb3, rows[0].a_limb3)
+        # b == base (all limbs)
+        cs.constrain_equal(rows[0].base_limb0, rows[0].b_limb0)
+        cs.constrain_equal(rows[0].base_limb1, rows[0].b_limb1)
+        cs.constrain_equal(rows[0].base_limb2, rows[0].b_limb2)
+        cs.constrain_equal(rows[0].base_limb3, rows[0].b_limb3)
+
+    # for every step
+    with cs.condition(rows[0].q_step) as cs:
+        # the intermediate exponentiation must equal the result of the corresponding multiplication.
+        cs.constrain_equal(rows[0].intermediate_exponentiation_lo, rows[0].d_lo)
+        cs.constrain_equal(rows[0].intermediate_exponentiation_hi, rows[0].d_hi)
+        # the c in multiply-add (a * b + c == d) should be 0 since we are only multiplying.
+        cs.constrain_zero(rows[0].c_lo)
+        cs.constrain_zero(rows[0].c_lo)
+        # remainder is a boolean.
+        cs.constrain_bool(rows[0].remainder)
+
+    # for all rows (except the last), where remainder == 1 (intermediate exponent -> odd)
+    with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * rows[0].remainder) as cs:
+        # intermediate_exponent::next == intermediate_exponent::cur - 1
+        # 1. lo::next == lo::cur - 1
+        cs.constrain_equal(rows[1].intermediate_exponent_lo, rows[0].intermediate_exponent_lo - 1)
+        # 2. hi::next == hi::cur
+        cs.constrain_equal(rows[1].intermediate_exponent_hi, rows[0].intermediate_exponent_hi)
+
+    # for all rows (except the last), where remainder == 0 (intermediate exponent -> even)
+    with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * (1 - rows[0].remainder)) as cs:
+        # intermediate_exponent::next == intermediate_exponent::cur / 2
+        cs.constrain_equal(rows[1].intermediate_exponent_lo * 2, rows[0].intermediate_exponent_lo)
+        cs.constrain_equal(rows[1].intermediate_exponent_hi * 2, rows[0].intermediate_exponent_hi)
+
+    # for the last step, intermediate exponent == 2
+    with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
+        cs.constrain_equal(rows[0].intermediate_exponent_lo, FQ(2))
+        cs.constrain_zero(rows[0].intermediate_exponent_hi)
 
 
 def verify_exp_circuit(exp_circuit: ExpCircuit):
@@ -19,18 +76,7 @@ def verify_exp_circuit(exp_circuit: ExpCircuit):
     n = len(exp_table)
     for i, row in enumerate(exp_table):
         rows = [
-            # 7 rows from q_step == 1
             row,
             exp_table[(i + 1) % n],
-            exp_table[(i + 2) % n],
-            exp_table[(i + 3) % n],
-            exp_table[(i + 4) % n],
-            exp_table[(i + 5) % n],
-            exp_table[(i + 6) % n],
-            # 4 rows from the next q_step == 1
-            exp_table[(i + 7) % n],
-            exp_table[(i + 8) % n],
-            exp_table[(i + 9) % n],
-            exp_table[(i + 10) % n],
         ]
         verify_step(cs, rows)

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -1,0 +1,36 @@
+from typing import List
+from .evm import (
+    ExpCircuit,
+    ExpCircuitRow,
+)
+from .util import (
+    ConstraintSystem,
+)
+
+
+def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
+    # TODO(rohit): implement
+    print("hello")
+
+
+def verify_exp_circuit(exp_circuit: ExpCircuit):
+    cs = ConstraintSystem()
+    exp_table = exp_circuit.table()
+    n = len(exp_table)
+    for i, row in enumerate(exp_table):
+        rows = [
+            # 7 rows from q_step == 1
+            row,
+            exp_table[(i + 1) % n],
+            exp_table[(i + 2) % n],
+            exp_table[(i + 3) % n],
+            exp_table[(i + 4) % n],
+            exp_table[(i + 5) % n],
+            exp_table[(i + 6) % n],
+            # 4 rows from the next q_step == 1
+            exp_table[(i + 7) % n],
+            exp_table[(i + 8) % n],
+            exp_table[(i + 9) % n],
+            exp_table[(i + 10) % n],
+        ]
+        verify_step(cs, rows)

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -21,13 +21,6 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         # the first multiplicand in the "cur" row `a`
         cs.constrain_equal(rows[0].a, rows[1].d)
 
-    # for the last row, we have: base * base == base^2
-    with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
-        # a == base
-        cs.constrain_equal(rows[0].base, rows[0].a)
-        # b == base
-        cs.constrain_equal(rows[0].base, rows[0].b)
-
     # for every step
     with cs.condition(rows[0].q_step) as cs:
         # multiplication is assigned correctly
@@ -65,6 +58,8 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         cs.constrain_equal(next_lo, cur_lo - 1)
         # hi::next == hi::cur
         cs.constrain_equal(next_hi, cur_hi)
+        # b == base
+        cs.constrain_equal(rows[0].base, rows[0].b)
 
     # for all rows (except the last), where remainder == 0 (intermediate exponent -> even)
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * (1 - rows[0].remainder)) as cs:
@@ -73,10 +68,17 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         next_lo, next_hi = word_to_lo_hi(rows[1].intermediate_exponent)
         cs.constrain_equal(next_lo * 2, cur_lo)
         cs.constrain_equal(next_hi * 2, cur_hi)
+        # a == b
+        cs.constrain_equal(rows[0].a, rows[0].b)
 
-    # for the last step, intermediate exponent == 2
+    # for the last step
     with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
+        # intermediate exponent == 2
         cs.constrain_equal(rows[0].intermediate_exponent.expr(), FQ(2))
+        # a == base
+        cs.constrain_equal(rows[0].base, rows[0].a)
+        # b == base
+        cs.constrain_equal(rows[0].base, rows[0].b)
 
 
 def verify_exp_circuit(exp_circuit: ExpCircuit):

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -1,5 +1,4 @@
-from enum import IntEnum, auto
-from typing import List, Set, Tuple
+from typing import List
 from .evm import (
     ExpCircuit,
     ExpCircuitRow,
@@ -7,28 +6,13 @@ from .evm import (
 from .util import (
     ConstraintSystem,
     FQ,
+    RLC,
     mul_add_words,
     word_to_lo_hi,
 )
 
 
-class FixedTableTag(IntEnum):
-    Odd = auto()
-    Even = auto()
-
-
-def _gen_fixed_table() -> Set[Tuple[FQ, FQ]]:
-    table: List[Tuple[FQ, FQ]] = []
-    # odd
-    for i in range(1, 256, 2):
-        table.append((FQ(FixedTableTag.Odd), FQ(i)))
-    # even
-    for i in range(0, 256, 2):
-        table.append((FQ(FixedTableTag.Even), FQ(i)))
-    return set(table)
-
-
-def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow], fixed_table: Set[Tuple[FQ, FQ]]):
+def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
     # for every step except the last
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last)) as cs:
         # base is the same across rows.
@@ -36,18 +20,20 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow], fixed_table: Se
         # multiplication result from the "next" row `d` must be used as
         # the first multiplicand in the "cur" row `a`
         cs.constrain_equal(rows[0].a, rows[1].d)
+        # identifier does not change over the steps of an exponentiation trace.
+        cs.constrain_equal(rows[0].identifier, rows[1].identifier)
 
     # for every step
     with cs.condition(rows[0].q_step) as cs:
-        # is_first and is_last are boolean values
-        cs.constrain_bool(rows[0].is_first)
+        # is_last is boolean.
         cs.constrain_bool(rows[0].is_last)
-        # is_first is followed by is_first == 0
-        cs.constrain_zero(rows[0].is_first * rows[1].is_first)
-        # if this is an intermediate step (is_first == 0) then is_first does not change.
-        cs.constrain_zero((1 - rows[0].is_first) * rows[1].is_first)
-        # is_last is followed by padding
-        cs.constrain_zero((1 - rows[0].is_last) * rows[1].is_pad)
+        # is_pad is boolean.
+        cs.constrain_bool(rows[0].is_pad)
+        # is_odd, i.e. odd/even parity is a boolean.
+        cs.constrain_bool(rows[0].is_odd)
+        # is_last == 1 is followed by is_pad == 1.
+        # is_last == 0 is following by is_pad == 0.
+        cs.constrain_equal(rows[0].is_last, rows[1].is_pad)
         # multiplication is assigned correctly
         _overflow, carry_lo_hi, additional_constraints = mul_add_words(
             rows[0].a, rows[0].b, rows[0].c, rows[0].d
@@ -56,24 +42,24 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow], fixed_table: Se
         cs.range_check(carry_lo_hi[1], 9)
         cs.constrain_equal(additional_constraints[0][0], additional_constraints[0][1])
         cs.constrain_equal(additional_constraints[1][0], additional_constraints[1][1])
-        # the intermediate exponentiation must equal the result of the corresponding multiplication.
-        cs.constrain_equal(rows[0].intermediate_exponentiation, rows[0].d)
+        # the exponentiation at this step must equal the result of the corresponding multiplication.
+        cs.constrain_equal(rows[0].exponentiation, rows[0].d)
         # the c in multiply-add (a * b + c == d) should be 0 since we are only multiplying.
         cs.constrain_zero(rows[0].c)
-        # is_odd, i.e. odd/even parity is a boolean.
-        cs.constrain_bool(rows[0].is_odd)
-
-    # lookup odd/even parity
-    if rows[0].is_odd == FQ.one():
-        assert (FQ(FixedTableTag.Odd), FQ(rows[0].lsb_intermediate_exponent)) in fixed_table
-    else:
-        assert (FQ(FixedTableTag.Even), FQ(rows[0].lsb_intermediate_exponent)) in fixed_table
+        # parity check multiplication is assigned correctly.
+        _overflow, carry_lo_hi, additional_constraints = mul_add_words(
+            RLC(2), rows[0].quotient, RLC(rows[0].is_odd.n), rows[0].exponent
+        )
+        cs.range_check(carry_lo_hi[0], 9)
+        cs.range_check(carry_lo_hi[1], 9)
+        cs.constrain_equal(additional_constraints[0][0], additional_constraints[0][1])
+        cs.constrain_equal(additional_constraints[1][0], additional_constraints[1][1])
 
     # for all steps (except the last), where exponent is odd
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * rows[0].is_odd) as cs:
-        # intermediate_exponent::next == intermediate_exponent::cur - 1
-        cur_lo, cur_hi = word_to_lo_hi(rows[0].intermediate_exponent)
-        next_lo, next_hi = word_to_lo_hi(rows[1].intermediate_exponent)
+        # exponent::next == exponent::cur - 1
+        cur_lo, cur_hi = word_to_lo_hi(rows[0].exponent)
+        next_lo, next_hi = word_to_lo_hi(rows[1].exponent)
         # lo::next == lo::cur - 1
         cs.constrain_equal(next_lo, cur_lo - 1)
         # hi::next == hi::cur
@@ -83,18 +69,22 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow], fixed_table: Se
 
     # for all steps (except the last), where exponent is even
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * (1 - rows[0].is_odd)) as cs:
-        # intermediate_exponent::next == intermediate_exponent::cur / 2
-        cur_lo, cur_hi = word_to_lo_hi(rows[0].intermediate_exponent)
-        next_lo, next_hi = word_to_lo_hi(rows[1].intermediate_exponent)
-        cs.constrain_equal(next_lo * 2, cur_lo)
-        cs.constrain_equal(next_hi * 2, cur_hi)
+        # exponent::next == exponent::cur / 2
+        cur_lo, cur_hi = word_to_lo_hi(rows[0].exponent)
+        next_lo, next_hi = word_to_lo_hi(rows[1].exponent)
+        quotient_lo, quotient_hi = word_to_lo_hi(rows[0].quotient)
+        # exponent::next == exponent::cur // 2 (equate next lo/hi)
+        cs.constrain_equal(next_lo, quotient_lo)
+        cs.constrain_equal(next_hi, quotient_hi)
         # a == b
         cs.constrain_equal(rows[0].a, rows[0].b)
 
     # for the last step
     with cs.condition(rows[0].is_last) as cs:
-        # intermediate exponent == 2
-        cs.constrain_equal(rows[0].intermediate_exponent.expr(), FQ(2))
+        # exponent == 2
+        exponent_lo, exponent_hi = word_to_lo_hi(rows[0].exponent)
+        cs.constrain_equal(exponent_lo, FQ(2))
+        cs.constrain_zero(exponent_hi)
         # a == base
         cs.constrain_equal(rows[0].base, rows[0].a)
         # b == base
@@ -105,10 +95,9 @@ def verify_exp_circuit(exp_circuit: ExpCircuit):
     cs = ConstraintSystem()
     exp_table = exp_circuit.table()
     n = len(exp_table)
-    fixed_table = _gen_fixed_table()
     for i, row in enumerate(exp_table):
         rows = [
             row,
             exp_table[(i + 1) % n],
         ]
-        verify_step(cs, rows, fixed_table)
+        verify_step(cs, rows)

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -6,47 +6,41 @@ from .evm import (
 from .util import (
     ConstraintSystem,
     FQ,
-    lo_hi_to_64s,
+    mul_add_words,
+    word_to_lo_hi,
 )
 
 
 def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
     # for every step except the last
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last)) as cs:
-        # base limbs are the same across rows.
-        cs.constrain_equal(rows[0].base_limb0, rows[1].base_limb0)
-        cs.constrain_equal(rows[0].base_limb1, rows[1].base_limb1)
-        cs.constrain_equal(rows[0].base_limb2, rows[1].base_limb2)
-        cs.constrain_equal(rows[0].base_limb3, rows[1].base_limb3)
+        # base is the same across rows.
+        cs.constrain_equal(rows[0].base, rows[1].base)
         # multiplication result from the "next" row `d` must be used as
         # the first multiplicand in the "cur" row `a`
-        d_next_limbs = lo_hi_to_64s((rows[1].d_lo, rows[1].d_hi))
-        cs.constrain_equal(rows[0].a_limb0, d_next_limbs[0])
-        cs.constrain_equal(rows[0].a_limb1, d_next_limbs[1])
-        cs.constrain_equal(rows[0].a_limb2, d_next_limbs[2])
-        cs.constrain_equal(rows[0].a_limb3, d_next_limbs[3])
+        cs.constrain_equal(rows[0].a, rows[1].d)
 
     # for the last row, we have: base * base == base^2
     with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
-        # a == base (all limbs)
-        cs.constrain_equal(rows[0].base_limb0, rows[0].a_limb0)
-        cs.constrain_equal(rows[0].base_limb1, rows[0].a_limb1)
-        cs.constrain_equal(rows[0].base_limb2, rows[0].a_limb2)
-        cs.constrain_equal(rows[0].base_limb3, rows[0].a_limb3)
-        # b == base (all limbs)
-        cs.constrain_equal(rows[0].base_limb0, rows[0].b_limb0)
-        cs.constrain_equal(rows[0].base_limb1, rows[0].b_limb1)
-        cs.constrain_equal(rows[0].base_limb2, rows[0].b_limb2)
-        cs.constrain_equal(rows[0].base_limb3, rows[0].b_limb3)
+        # a == base
+        cs.constrain_equal(rows[0].base, rows[0].a)
+        # b == base
+        cs.constrain_equal(rows[0].base, rows[0].b)
 
     # for every step
     with cs.condition(rows[0].q_step) as cs:
+        # multiplication is assigned correctly
+        _overflow, carry_lo_hi, additional_constraints = mul_add_words(
+            rows[0].a, rows[0].b, rows[0].c, rows[0].d
+        )
+        cs.range_check(carry_lo_hi[0], 9)
+        cs.range_check(carry_lo_hi[1], 9)
+        cs.constrain_equal(additional_constraints[0][0], additional_constraints[0][1])
+        cs.constrain_equal(additional_constraints[1][0], additional_constraints[1][1])
         # the intermediate exponentiation must equal the result of the corresponding multiplication.
-        cs.constrain_equal(rows[0].intermediate_exponentiation_lo, rows[0].d_lo)
-        cs.constrain_equal(rows[0].intermediate_exponentiation_hi, rows[0].d_hi)
+        cs.constrain_equal(rows[0].intermediate_exponentiation, rows[0].d)
         # the c in multiply-add (a * b + c == d) should be 0 since we are only multiplying.
-        cs.constrain_zero(rows[0].c_lo)
-        cs.constrain_zero(rows[0].c_lo)
+        cs.constrain_zero(rows[0].c)
         # remainder is a boolean.
         cs.constrain_bool(rows[0].remainder)
         # TODO(rohit): remainder is correct, i.e. remainder == intermediate_exponent % 2
@@ -54,21 +48,24 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
     # for all rows (except the last), where remainder == 1 (intermediate exponent -> odd)
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * rows[0].remainder) as cs:
         # intermediate_exponent::next == intermediate_exponent::cur - 1
-        # 1. lo::next == lo::cur - 1
-        cs.constrain_equal(rows[1].intermediate_exponent_lo, rows[0].intermediate_exponent_lo - 1)
-        # 2. hi::next == hi::cur
-        cs.constrain_equal(rows[1].intermediate_exponent_hi, rows[0].intermediate_exponent_hi)
+        cur_lo, cur_hi = word_to_lo_hi(rows[0].intermediate_exponent)
+        next_lo, next_hi = word_to_lo_hi(rows[1].intermediate_exponent)
+        # lo::next == lo::cur - 1
+        cs.constrain_equal(next_lo, cur_lo - 1)
+        # hi::next == hi::cur
+        cs.constrain_equal(next_hi, cur_hi)
 
     # for all rows (except the last), where remainder == 0 (intermediate exponent -> even)
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * (1 - rows[0].remainder)) as cs:
         # intermediate_exponent::next == intermediate_exponent::cur / 2
-        cs.constrain_equal(rows[1].intermediate_exponent_lo * 2, rows[0].intermediate_exponent_lo)
-        cs.constrain_equal(rows[1].intermediate_exponent_hi * 2, rows[0].intermediate_exponent_hi)
+        cur_lo, cur_hi = word_to_lo_hi(rows[0].intermediate_exponent)
+        next_lo, next_hi = word_to_lo_hi(rows[1].intermediate_exponent)
+        cs.constrain_equal(next_lo * 2, cur_lo)
+        cs.constrain_equal(next_hi * 2, cur_hi)
 
     # for the last step, intermediate exponent == 2
     with cs.condition(rows[0].q_step * rows[0].is_last) as cs:
-        cs.constrain_equal(rows[0].intermediate_exponent_lo, FQ(2))
-        cs.constrain_zero(rows[0].intermediate_exponent_hi)
+        cs.constrain_equal(rows[0].intermediate_exponent.expr(), FQ(2))
 
 
 def verify_exp_circuit(exp_circuit: ExpCircuit):

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -49,6 +49,7 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         cs.constrain_zero(rows[0].c_lo)
         # remainder is a boolean.
         cs.constrain_bool(rows[0].remainder)
+        # TODO(rohit): remainder is correct, i.e. remainder == intermediate_exponent % 2
 
     # for all rows (except the last), where remainder == 1 (intermediate exponent -> odd)
     with cs.condition(rows[0].q_step * (1 - rows[0].is_last) * rows[0].remainder) as cs:

--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -26,6 +26,12 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         # is_first and is_last are boolean values
         cs.constrain_bool(rows[0].is_first)
         cs.constrain_bool(rows[0].is_last)
+        # is_first is followed by is_first == 0
+        cs.constrain_zero(rows[0].is_first * rows[1].is_first)
+        # if this is an intermediate step (is_first == 0) then is_first does not change.
+        cs.constrain_zero((1 - rows[0].is_first) * rows[1].is_first)
+        # is_last is followed by padding
+        cs.constrain_zero((1 - rows[0].is_last) * rows[1].is_pad)
         # multiplication is assigned correctly
         _overflow, carry_lo_hi, additional_constraints = mul_add_words(
             rows[0].a, rows[0].b, rows[0].c, rows[0].d

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -107,3 +107,14 @@ def word_to_lo_hi(word: RLC) -> Tuple[FQ, FQ]:
 def word_to_64s(word: RLC) -> Tuple[FQ, ...]:
     assert len(word.le_bytes) == 32, "Expected word to contain 32 bytes"
     return tuple(bytes_to_fq(word.le_bytes[8 * i : 8 * (i + 1)]) for i in range(4))
+
+
+def lo_hi_to_64s(lo_hi: Tuple[FQ, FQ]) -> Tuple[FQ, ...]:
+    lo_bytes = lo_hi[0].n.to_bytes(16, "little")
+    hi_bytes = lo_hi[1].n.to_bytes(16, "little")
+    return (
+        bytes_to_fq(lo_bytes[0:8]),
+        bytes_to_fq(lo_bytes[8:16]),
+        bytes_to_fq(hi_bytes[0:8]),
+        bytes_to_fq(hi_bytes[8:16]),
+    )

--- a/src/zkevm_specs/util/constraint_system.py
+++ b/src/zkevm_specs/util/constraint_system.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from .arithmetic import Expression, FQ
+from .param import MAX_N_BYTES
 
 
 class ConstraintUnsatFailure(Exception):
@@ -45,6 +46,13 @@ class ConstraintSystem:
 
     def is_zero(self, value: Expression) -> FQ:
         return FQ(value.expr() == 0)
+
+    def range_check(self, value: Expression, n_bytes: int) -> bytes:
+        assert n_bytes <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
+        try:
+            return value.expr().n.to_bytes(n_bytes, "little")
+        except OverflowError:
+            raise ConstraintUnsatFailure(f"Value {value} has too many bytes to fit {n_bytes} bytes")
 
     def condition(self, cond: Expression):
         assert self.cond is None, "Don't support recursive conditions"

--- a/src/zkevm_specs/util/constraint_system.py
+++ b/src/zkevm_specs/util/constraint_system.py
@@ -47,6 +47,9 @@ class ConstraintSystem:
     def is_zero(self, value: Expression) -> FQ:
         return FQ(value.expr() == 0)
 
+    def is_equal(self, lhs: Expression, rhs: Expression) -> FQ:
+        return self.is_zero(lhs.expr() - rhs.expr())
+
     def range_check(self, value: Expression, n_bytes: int) -> bytes:
         assert n_bytes <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
         try:

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -31,6 +31,8 @@ GAS_COST_MID = 8
 GAS_COST_SLOW = 10
 # Gas cost of ext step
 GAS_COST_EXT = 20
+# Gas cost (dynamic) per exponent byte-size
+GAS_COST_EXP_PER_BYTE = 50
 # Gas cost of SHA3
 GAS_COST_SHA3 = 30
 # Gas cost of CREATE

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -66,7 +66,7 @@ def test_exp(base: int, exponent: int):
         .stack_write(CALL_ID, 1023, exponentiation_rlc)
     )
 
-    exp_circuit = ExpCircuit().add_event(base, exponent, randomness)
+    exp_circuit = ExpCircuit().add_event(base, exponent, randomness).append_padding_rows()
 
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -66,7 +66,7 @@ def test_exp(base: int, exponent: int):
         .stack_write(CALL_ID, 1023, exponentiation_rlc)
     )
 
-    exp_circuit = ExpCircuit().add_event(base, exponent, randomness)
+    exp_circuit = ExpCircuit().add_event(base, exponent, randomness, rw_dict.rw_counter)
 
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -66,7 +66,7 @@ def test_exp(base: int, exponent: int):
         .stack_write(CALL_ID, 1023, exponentiation_rlc)
     )
 
-    exp_circuit = ExpCircuit().add_event(base, exponent, randomness).append_padding_rows()
+    exp_circuit = ExpCircuit().add_event(base, exponent, randomness)
 
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -7,13 +7,15 @@ from zkevm_specs.evm import (
     Bytecode,
     ExecutionState,
     ExpCircuit,
+    Opcode,
     RWDictionary,
     StepState,
     Tables,
-    verify_exp_circuit,
     verify_steps,
 )
+from zkevm_specs.exp_circuit import verify_exp_circuit
 from zkevm_specs.util import (
+    byte_size,
     rand_fq,
     RLC,
 )
@@ -25,17 +27,17 @@ TESTING_DATA = (
     (0, 0),
     (1, 0),
     (0xCAFE, 0),
-    (POW2, 0),
+    (POW2 - 1, 0),
     (0, 1),
     (1, 1),
     (0xCAFE, 1),
-    (POW2, 1),
+    (POW2 - 1, 1),
     (2, 5),
     (3, 101),
     (5, 259),
     (7, 1023),
-    (POW2, 2),
-    (POW2, 3),
+    (POW2 - 1, 2),
+    (POW2 - 1, 3),
 )
 
 
@@ -61,7 +63,7 @@ def test_exp(base: int, exponent: int):
         .stack_write(CALL_ID, 1023, exponentiation_rlc)
     )
 
-    exp_circuit = ExpCircuit().add_event(base, exponent)
+    exp_circuit = ExpCircuit().add_event(base, exponent, randomness)
 
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),
@@ -91,7 +93,7 @@ def test_exp(base: int, exponent: int):
             ),
             StepState(
                 execution_state=ExecutionState.STOP,
-                rw_counter=rw_dictionary.rw_counter,
+                rw_counter=rw_dict.rw_counter,
                 call_id=CALL_ID,
                 is_root=True,
                 is_create=False,

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -28,7 +28,9 @@ CALL_ID = 1
 POW2 = 2**256
 TESTING_DATA = (
     (0, 0),
+    (0, POW2 - 1),
     (1, 0),
+    (1, POW2 - 1),
     (0xCAFE, 0),
     (POW2 - 1, 0),
     (0, 1),
@@ -41,6 +43,7 @@ TESTING_DATA = (
     (7, 1023),
     (POW2 - 1, 2),
     (POW2 - 1, 3),
+    (POW2 - 1, POW2 - 1),
 )
 
 
@@ -48,7 +51,7 @@ TESTING_DATA = (
 def test_exp(base: int, exponent: int):
     randomness = rand_fq()
 
-    exponentiation = (base**exponent) % POW2
+    exponentiation = pow(base, exponent, POW2)
 
     bytecode = Bytecode().push(exponent, n_bytes=32).push(base, n_bytes=32).exp().stop()
     bytecode_hash = RLC(bytecode.hash(), randomness)

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -18,6 +18,9 @@ from zkevm_specs.util import (
     byte_size,
     rand_fq,
     RLC,
+    # hi
+    word_to_lo_hi,
+    word_to_64s,
 )
 
 

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -22,7 +22,7 @@ from zkevm_specs.util import (
 
 
 CALL_ID = 1
-POW2 = 2**256 - 1
+POW2 = 2**256
 TESTING_DATA = (
     (0, 0),
     (1, 0),

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -1,0 +1,104 @@
+import pytest
+
+
+from zkevm_specs.evm import (
+    GAS_COST_EXP_PER_BYTE,
+    Block,
+    Bytecode,
+    ExecutionState,
+    ExpCircuit,
+    RWDictionary,
+    StepState,
+    Tables,
+    verify_exp_circuit,
+    verify_steps,
+)
+from zkevm_specs.util import (
+    rand_fq,
+    RLC,
+)
+
+
+CALL_ID = 1
+POW2 = 2**256 - 1
+TESTING_DATA = (
+    (0, 0),
+    (1, 0),
+    (0xCAFE, 0),
+    (POW2, 0),
+    (0, 1),
+    (1, 1),
+    (0xCAFE, 1),
+    (POW2, 1),
+    (2, 5),
+    (3, 101),
+    (5, 259),
+    (7, 1023),
+    (POW2, 2),
+    (POW2, 3),
+)
+
+
+@pytest.mark.parametrize("base, exponent", TESTING_DATA)
+def test_exp(base: int, exponent: int):
+    randomness = rand_fq()
+
+    exponentiation = (base**exponent) % POW2
+
+    bytecode = Bytecode().push(exponent, n_bytes=32).push(base, n_bytes=32).exp().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
+
+    base_rlc = RLC(base, randomness, n_bytes=32)
+    exponent_rlc = RLC(exponent, randomness, n_bytes=32)
+    exponentiation_rlc = RLC(exponentiation, randomness, n_bytes=32)
+
+    rw_dict = (
+        RWDictionary(1)
+        .stack_write(CALL_ID, 1023, exponent_rlc)
+        .stack_write(CALL_ID, 1022, base_rlc)
+        .stack_read(CALL_ID, 1022, base_rlc)
+        .stack_read(CALL_ID, 1023, exponent_rlc)
+        .stack_write(CALL_ID, 1023, exponentiation_rlc)
+    )
+
+    exp_circuit = ExpCircuit().add_event(base, exponent)
+
+    tables = Tables(
+        block_table=set(Block().table_assignments(randomness)),
+        tx_table=set(),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
+        rw_table=set(rw_dict.rws),
+        exp_circuit=exp_circuit.rows,
+    )
+
+    verify_exp_circuit(exp_circuit)
+
+    gas = Opcode.EXP.constant_gas_cost() + byte_size(exponent) * GAS_COST_EXP_PER_BYTE
+    verify_steps(
+        randomness=randomness,
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.EXP,
+                rw_counter=3,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=66,
+                stack_pointer=1022,
+                gas_left=gas,
+            ),
+            StepState(
+                execution_state=ExecutionState.STOP,
+                rw_counter=rw_dictionary.rw_counter,
+                call_id=CALL_ID,
+                is_root=True,
+                is_create=False,
+                code_hash=bytecode_hash,
+                program_counter=67,
+                stack_pointer=1023,
+                gas_left=0,
+            ),
+        ],
+    )


### PR DESCRIPTION
* Design Document: https://hackmd.io/@rohitnarurkar/BJhpYGiCc
* Circuits Implementation: https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/700

This PR implements the following:
- [x] EXP Gadget
- [x] Exponentiation Circuit
- [x] Exponentiation Table (verified within Exponentiation Circuit)

The `EXP` opcode computes the exponentiation result of an integer base to an integer exponent:
```
base ^ exponent == exponentiation (mod 2^256)
```

The  exponentiation circuit verifies the exponentiation trace, i.e. intermediate multiplication steps generated by the [Exponentiation by Squaring](https://hackmd.io/@rohitnarurkar/BJhpYGiCc#Background) algorithm.

The `EXP` opcode gadget does lookups (conditional based on the `exponent` value) to the exponentiation table.