### PR TITLE
MPT lookup proof type selectors

### DIFF
--- a/specs/tables.md
+++ b/specs/tables.md
@@ -199,7 +199,7 @@ Provided by the MPT (Merkle Patricia Trie) circuit.
 The current MPT circuit design exposes one big table where different targets require different lookups as described below.
 From this table, the following columns contain values using the RLC encoding:
 - Address
-- FieldTag
+- ProofType
 - Key
 - ValuePrev
 - Value
@@ -208,12 +208,12 @@ From this table, the following columns contain values using the RLC encoding:
 
 The circuit can prove that updates to account nonces, balances, or storage slots are correct, or that an account's code hash is some particular value. Note that it is not possible to change the code hash for an account without deleting it and then recreating it.
 
-| Address | FieldTag | Key | ValuePrev | Value | RootPrev | Root |
+| Address | ProofType | Key | ValuePrev | Value | RootPrev | Root |
 | - | - | - | - | - | - | - |
-| $addr | Nonce | 0 | $noncePrev | $nonceCur | $rootPrev | $root |
-| $addr | Balance | 0 | $balancePrev | $balanceCur | $rootPrev | $root |
-| $addr | CodeHash | 0 |$codeHash | $codeHash | $rootPrev | $root |
-| $addr | Storage | $key | $valuePrev | $value | $rootPrev | $root |
+| $addr | IsNonceMod | 0 | $noncePrev | $nonceCur | $rootPrev | $root |
+| $addr | IsBalanceMod | 0 | $balancePrev | $balanceCur | $rootPrev | $root |
+| $addr | IsCodeHashProof | 0 |$codeHash | $codeHash | $rootPrev | $root |
+| $addr | IsStorageMod | $key | $valuePrev | $value | $rootPrev | $root |
 
 ## Keccak Table
 

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -210,10 +210,12 @@ The circuit can prove that updates to account nonces, balances, or storage slots
 
 | Address | ProofType | Key | ValuePrev | Value | RootPrev | Root |
 | - | - | - | - | - | - | - |
-| $addr | IsNonceMod | 0 | $noncePrev | $nonceCur | $rootPrev | $root |
-| $addr | IsBalanceMod | 0 | $balancePrev | $balanceCur | $rootPrev | $root |
-| $addr | IsCodeHashProof | 0 |$codeHash | $codeHash | $rootPrev | $root |
-| $addr | IsStorageMod | $key | $valuePrev | $value | $rootPrev | $root |
+| $addr | NonceMod | 0 | $noncePrev | $nonceCur | $rootPrev | $root |
+| $addr | BalanceMod | 0 | $balancePrev | $balanceCur | $rootPrev | $root |
+| $addr | CodeHashProof | 0 | $codeHash | $codeHash | $rootPrev | $root |
+| $addr | StorageMod | $key | $valuePrev | $value | $rootPrev | $root |
+| $addr | AccountDeleteMod | 0 | 0 | 0 | $rootPrev | $root |
+| $addr | NonExistingAccountProof | 0 | 0 | 0 | $rootPrev | $root |
 
 ## Keccak Table
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -305,12 +305,20 @@ class MPTProofType(IntEnum):
     Tag for MPT lookup.
     """
 
-    IsStorageMod = auto()
-    IsNonceMod = auto()
-    IsBalanceMod = auto()
-    IsCodeHashProof = auto()
-    IsAccountDeleteMod = auto()
-    IsNonExistingAccountProof = auto()
+    NonceMod = auto()
+    BalanceMod = auto()
+    CodeHashProof = auto()
+    AccountDeleteMod = auto()
+    NonExistingAccountProof = auto()
+    StorageMod = auto()
+
+    def from_account_field_tag(field_tag: AccountFieldTag) -> MPTProofType:
+        if field_tag == AccountFieldTag.Nonce:
+            return MPTProofType.NonceMod
+        elif field_tag == AccountFieldTag.Balance:
+            return MPTProofType.BalanceMod
+        elif field_tag == AccountFieldTag.CodeHash:
+            return MPTProofType.CodeHashProof
 
 
 class WrongQueryKey(Exception):

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -312,13 +312,13 @@ class MPTProofType(IntEnum):
     NonExistingAccountProof = auto()
     StorageMod = auto()
 
+    @staticmethod
     def from_account_field_tag(field_tag: AccountFieldTag) -> MPTProofType:
-        if field_tag == AccountFieldTag.Nonce:
-            return MPTProofType.NonceMod
-        elif field_tag == AccountFieldTag.Balance:
+        if field_tag == AccountFieldTag.Balance:
             return MPTProofType.BalanceMod
         elif field_tag == AccountFieldTag.CodeHash:
             return MPTProofType.CodeHashProof
+        return MPTProofType.NonceMod
 
 
 class WrongQueryKey(Exception):

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -299,6 +299,18 @@ class CopyDataTypeTag(IntEnum):
     # the Keccak table for the SHA3 of the input bytes.
     RlcAcc = auto()
 
+class MPTProofType(IntEnum):
+    """
+    Tag for MPT lookup.
+    """
+
+    IsStorageMod = auto()
+    IsNonceMod = auto()
+    IsBalanceMod = auto()
+    IsCodeHashProof = auto()
+    IsAccountDeleteMod = auto()
+    IsNonExistingAccountProof = auto()
+
 
 class WrongQueryKey(Exception):
     def __init__(self, table_name: str, diff: Set[str]) -> None:
@@ -380,7 +392,7 @@ class RWTableRow(TableRow):
 @dataclass(frozen=True)
 class MPTTableRow(TableRow):
     address: Expression
-    field_tag: Expression
+    proof_type: Expression
     storage_key: Expression
     root: Expression
     root_prev: Expression

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -299,6 +299,7 @@ class CopyDataTypeTag(IntEnum):
     # the Keccak table for the SHA3 of the input bytes.
     RlcAcc = auto()
 
+
 class MPTProofType(IntEnum):
     """
     Tag for MPT lookup.

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -129,7 +129,7 @@ class Tables:
     ) -> MPTTableRow:
         query = {
             "address": address,
-            "proof_type": FQ(proof_type),
+            "proof_type": proof_type,
             "storage_key": storage_key,
             "value": value,
             "value_prev": value_prev,
@@ -240,7 +240,7 @@ def check_storage(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     if not all_keys_eq(row, row_next):
         tables.mpt_lookup(
             row.address(),
-            MPTProofType.IsStorageMod,
+            FQ(MPTProofType.IsStorageMod),
             row.storage_key(),
             row.value,
             row.committed_value,
@@ -271,7 +271,7 @@ def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     get_addr = lambda row: row.address()
 
     field_tag = row.field_tag()
-    proof_type = None
+    proof_type = MPTProofType.IsNonceMod
     if field_tag == AccountFieldTag.Nonce:
         proof_type = MPTProofType.IsNonceMod
     elif field_tag == AccountFieldTag.Balance:
@@ -287,7 +287,7 @@ def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     if not all_keys_eq(row, row_next):
         tables.mpt_lookup(
             get_addr(row),
-            proof_type,
+            FQ(proof_type),
             row.storage_key(),
             row.value,
             row.committed_value,
@@ -827,7 +827,7 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
             continue
 
         field_tag = op.field_tag
-        proof_type = None
+        proof_type = MPTProofType.IsStorageMod
         if field_tag == 0:
             proof_type = MPTProofType.IsStorageMod
         elif field_tag == AccountFieldTag.Nonce:

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -819,7 +819,7 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
     # makes fake mpt updates for a list of rows. the state root starts at 5 and
     # is incremented by 3 for each Account or Storage MPT update.
     mpt_map = {}
- 
+
     root = 3
     for op in ops:
         mpt_key = _mpt_key(op)

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -824,7 +824,7 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
         proof_type = MPTProofType.StorageMod  # type warning if None
         if isinstance(field_tag, AccountFieldTag):
             proof_type = MPTProofType.from_account_field_tag(field_tag)
-        
+
         new_root = root + 5
         mpt_map[mpt_key] = MPTTableRow(
             FQ(op.address),

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -2,6 +2,8 @@ from typing import NamedTuple, Tuple, List, Set, Dict, Optional
 from enum import IntEnum
 from math import log, ceil
 
+from zkevm_specs.evm.table import MPTProofType
+
 from .util import FQ, RLC, U160, U256, Expression, linear_combine
 from .encoding import U8, is_circuit_code
 from .evm import (
@@ -118,7 +120,7 @@ class Tables:
     def mpt_lookup(
         self,
         address: Expression,
-        field_tag: Expression,
+        proof_type: Expression,
         storage_key: Expression,
         value: Expression,
         value_prev: Expression,
@@ -127,7 +129,7 @@ class Tables:
     ) -> MPTTableRow:
         query = {
             "address": address,
-            "field_tag": field_tag,
+            "proof_type": FQ(proof_type),
             "storage_key": storage_key,
             "value": value,
             "value_prev": value_prev,
@@ -238,7 +240,7 @@ def check_storage(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     if not all_keys_eq(row, row_next):
         tables.mpt_lookup(
             row.address(),
-            row.field_tag(),
+            MPTProofType.IsStorageMod,
             row.storage_key(),
             row.value,
             row.committed_value,
@@ -267,7 +269,15 @@ def check_call_context(row: Row, row_prev: Row):
 @is_circuit_code
 def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     get_addr = lambda row: row.address()
-    get_field_tag = lambda row: row.field_tag()
+
+    field_tag = row.field_tag()
+    proof_type = None
+    if field_tag == AccountFieldTag.Nonce:
+        proof_type = MPTProofType.IsNonceMod
+    elif field_tag == AccountFieldTag.Balance:
+        proof_type = MPTProofType.IsBalanceMod
+    elif field_tag == AccountFieldTag.CodeHash:
+        proof_type = MPTProofType.IsCodeHashProof
 
     # 6.0. Unused keys are 0
     assert row.id() == 0
@@ -277,7 +287,7 @@ def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     if not all_keys_eq(row, row_next):
         tables.mpt_lookup(
             get_addr(row),
-            get_field_tag(row),
+            proof_type,
             row.storage_key(),
             row.value,
             row.committed_value,
@@ -809,17 +819,28 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
     # makes fake mpt updates for a list of rows. the state root starts at 5 and
     # is incremented by 3 for each Account or Storage MPT update.
     mpt_map = {}
-
+ 
     root = 3
     for op in ops:
         mpt_key = _mpt_key(op)
         if mpt_key is None or mpt_key in mpt_map:
             continue
 
+        field_tag = op.field_tag
+        proof_type = None
+        if field_tag == 0:
+            proof_type = MPTProofType.IsStorageMod
+        elif field_tag == AccountFieldTag.Nonce:
+            proof_type = MPTProofType.IsNonceMod
+        elif field_tag == AccountFieldTag.Balance:
+            proof_type = MPTProofType.IsBalanceMod
+        elif field_tag == AccountFieldTag.CodeHash:
+            proof_type = MPTProofType.IsCodeHashProof
+
         new_root = root + 5
         mpt_map[mpt_key] = MPTTableRow(
             FQ(op.address),
-            FQ(op.field_tag),
+            FQ(proof_type),
             RLC(op.storage_key, randomness).expr(),
             FQ(new_root),
             FQ(root),

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -271,10 +271,8 @@ def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     get_addr = lambda row: row.address()
 
     field_tag = row.field_tag()
-    proof_type = MPTProofType.IsNonceMod
-    if field_tag == AccountFieldTag.Nonce:
-        proof_type = MPTProofType.IsNonceMod
-    elif field_tag == AccountFieldTag.Balance:
+    proof_type = MPTProofType.IsNonceMod # type warning if None
+    if field_tag == AccountFieldTag.Balance:
         proof_type = MPTProofType.IsBalanceMod
     elif field_tag == AccountFieldTag.CodeHash:
         proof_type = MPTProofType.IsCodeHashProof
@@ -827,10 +825,8 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
             continue
 
         field_tag = op.field_tag
-        proof_type = MPTProofType.IsStorageMod
-        if field_tag == 0:
-            proof_type = MPTProofType.IsStorageMod
-        elif field_tag == AccountFieldTag.Nonce:
+        proof_type = MPTProofType.IsStorageMod # type warning if None
+        if field_tag == AccountFieldTag.Nonce:
             proof_type = MPTProofType.IsNonceMod
         elif field_tag == AccountFieldTag.Balance:
             proof_type = MPTProofType.IsBalanceMod

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -271,7 +271,7 @@ def check_account(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     get_addr = lambda row: row.address()
 
     field_tag = row.field_tag()
-    proof_type = MPTProofType.IsNonceMod # type warning if None
+    proof_type = MPTProofType.IsNonceMod  # type warning if None
     if field_tag == AccountFieldTag.Balance:
         proof_type = MPTProofType.IsBalanceMod
     elif field_tag == AccountFieldTag.CodeHash:
@@ -825,7 +825,7 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
             continue
 
         field_tag = op.field_tag
-        proof_type = MPTProofType.IsStorageMod # type warning if None
+        proof_type = MPTProofType.IsStorageMod  # type warning if None
         if field_tag == AccountFieldTag.Nonce:
             proof_type = MPTProofType.IsNonceMod
         elif field_tag == AccountFieldTag.Balance:


### PR DESCRIPTION
Added `proof_type` instead of `field_tag` into MPT lookup.

`proof_type` can be:

```
IsStorageMod
IsNonceMod
IsBalanceMod
IsCodeHashProof
IsAccountDeleteMod
IsNonExistingAccountProof
```
