### PR TITLE
CodeHashProof changed to CodeHashMod

### DIFF
--- a/specs/tables.md
+++ b/specs/tables.md
@@ -212,7 +212,7 @@ The circuit can prove that updates to account nonces, balances, or storage slots
 | - | - | - | - | - | - | - |
 | $addr | NonceMod | 0 | $noncePrev | $nonceCur | $rootPrev | $root |
 | $addr | BalanceMod | 0 | $balancePrev | $balanceCur | $rootPrev | $root |
-| $addr | CodeHashProof | 0 | $codeHash | $codeHash | $rootPrev | $root |
+| $addr | CodeHashMod | 0 | $codeHashPrev | $codeHashCur | $rootPrev | $root |
 | $addr | StorageMod | $key | $valuePrev | $value | $rootPrev | $root |
 | $addr | AccountDeleteMod | 0 | 0 | 0 | $rootPrev | $root |
 | $addr | NonExistingAccountProof | 0 | 0 | 0 | $rootPrev | $root |

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -313,19 +313,19 @@ class MPTProofType(IntEnum):
     Tag for MPT lookup.
     """
 
-    NonceMod = auto()
-    BalanceMod = auto()
-    CodeHashProof = auto()
-    AccountDeleteMod = auto()
-    NonExistingAccountProof = auto()
-    StorageMod = auto()
+    StorageMod = 0
+    NonceMod = 1
+    BalanceMod = 2
+    CodeHashMod = 3
+    AccountDeleteMod = 4
+    NonExistingAccountProof = 5
 
     @staticmethod
     def from_account_field_tag(field_tag: AccountFieldTag) -> MPTProofType:
         if field_tag == AccountFieldTag.Balance:
             return MPTProofType.BalanceMod
         elif field_tag == AccountFieldTag.CodeHash:
-            return MPTProofType.CodeHashProof
+            return MPTProofType.CodeHashMod
         return MPTProofType.NonceMod
 
 


### PR DESCRIPTION
MPT circuit should support code hash modifications, not just proving that an account has a particular code hash.

By @ed255 :
I think the case where CodeHash goes from default to a non-default value should be supported.  And further more, I think this case can happen when the account leaf already exists.  Here's an example
- Someone precomputes the address that a contract with CREATE2 will have, and sends some balance to that address.  Now we have a new leaf account with balance > 0, and codeHash = default.
- Then CREATE2 is called which will need to update the codeHash of the already existing leaf from default to non-default value