### PR TITLE
PublicInput circuit: reduce the length of raw public input column

### DIFF
--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -171,14 +171,11 @@ def check_row(
             + FQ(GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE) * is_byte_next_zero
         )
 
-        tx_id_diff = row_next.tx_table.tx_id - row.tx_table.tx_id - one
-        tx_id_constraint = (
-            (row_next.tx_table.tx_id - row.tx_table.tx_id)
-            * (row_next.tx_table.tx_id - row.tx_table.tx_id - one - tx_id_diff)
-            * row_next.tx_table.tx_id
-        )
-        tx_id_diff_query = {"value": tx_id_not_equal_to_next * is_tx_id_next_nonzero * tx_id_diff}
-        lookup(FixedU16Row, fixed_u16_table, tx_id_diff_query)
+        tx_id_diff_minus_one = row_next.tx_table.tx_id - row.tx_table.tx_id - one
+        tx_id_diff_minus_one_query = {
+            "value": tx_id_not_equal_to_next * is_tx_id_next_nonzero * tx_id_diff_minus_one
+        }
+        lookup(FixedU16Row, fixed_u16_table, tx_id_diff_minus_one_query)
 
         idx_of_same_tx_constraint = tx_id_equal_to_next * (
             row_next.tx_table.index - row.tx_table.index - one
@@ -201,7 +198,6 @@ def check_row(
         )
 
         constraints = [
-            tx_id_constraint,
             is_tx_id_nonzero * idx_of_same_tx_constraint,
             is_tx_id_nonzero * idx_of_next_tx_constraint,
             is_tx_id_nonzero * gas_cost_of_same_tx_constraint,

--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -470,10 +470,14 @@ def public_data2witness(
     tx_table_tx_fields = public_data.tx_table_tx_fields(MAX_TXS)
     tx_table_tx_calldata = public_data.tx_table_tx_calldata(MAX_CALLDATA_BYTES)
     raw_public_inputs.extend(
-        [0] + tx_table_tx_fields[0]
+        [FQ(0)] + tx_table_tx_fields[0]
     )  # start offset = BLOCK_LEN + 1 + EXTRA_LEN
-    raw_public_inputs.extend([0] + tx_table_tx_fields[1])  # start offset += (TX_LEN * MAX_TXS + 1)
-    raw_public_inputs.extend([0] + tx_table_tx_fields[2])  # start offset += (TX_LEN * MAX_TXS + 1)
+    raw_public_inputs.extend(
+        [FQ(0)] + tx_table_tx_fields[1]
+    )  # start offset += (TX_LEN * MAX_TXS + 1)
+    raw_public_inputs.extend(
+        [FQ(0)] + tx_table_tx_fields[2]
+    )  # start offset += (TX_LEN * MAX_TXS + 1)
     raw_public_inputs.extend(tx_table_tx_calldata[2])  # start offset += (TX_LEN * MAX_TXS + 1)
 
     assert (

--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -41,6 +41,7 @@ class TxCallDataGasCostAccRow(TableRow):
     is_final: FQ
     gas_cost_acc: FQ
 
+
 @dataclass
 class Row:
     """PublicInputs circuit row"""
@@ -53,7 +54,7 @@ class Row:
     q_tx_calldata_start: FQ  # Fixed Column
     tx_table: TxTableRow
     tx_id_inv: FQ  # (tx_tag - CallDataLength)^(-1) when q_tx_table = 1
-                   # tx_id^(-1) when q_tx_calldata = 1
+    # tx_id^(-1) when q_tx_calldata = 1
     tx_value_inv: FQ
     calldata_gas_cost: FQ
     is_final: FQ

--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -118,6 +118,10 @@ def check_row(
         row.q_tx_table * row.tx_table.value
         == row.q_tx_table * row_offset_tx_table_value.raw_public_inputs
     )
+    assert (
+        row.q_tx_calldata * row.tx_table.value
+        == row.q_tx_calldata * row_offset_tx_table_value.raw_public_inputs
+    )
 
     zero = FQ(0)
     one = FQ(1)


### PR DESCRIPTION
- In this PR, we aim to reduce the num of rows used by `raw_public_input`(abbr. rpi) col by adding constraints on tx_table. The length of the `rpi` col is reduced from 

    > `BLOCK_LEN + 1 + 3 * (TX_LEN * MAX_TXs + 1) + 3 * MAX_CALLDATABYTES` to
    > `BLOCK_LEN + 1 + 3 * (TX_LEN * MAX_TXs + 1) + MAX_CALLDATABYTES`. 

    The current circuit includes the `tx_id` and `index` part of the calldata bytes in the raw public input col which is not necessary 
      as these fields has good simple pattern. 

     |tx_id | tag | index | value |
     |-|-|-|-|
     | 1 | CallData | 1 | tx[0].data[0] |
     | 1 | CallData | 2 | tx[0].data[1] |
     |... | CallData | .. | tx[0].data[..] |
     | 2 | CallData | 1 | tx[1].data[0] |
     | 2 | CallData | 2 | tx[1].data[1] |
     |... | CallData | .. | tx[..].data[..] |
     | 0 | CallData | 0 | 0 |
     | 0 | CallData | 0 | 0 |
     |... | CallData | .. | 0 |

- Moreover, the `calldata_gas_cost` field can be accumulated inside the circuit, so we can reduce the gas cost in solidity verifier contract.