### PR TITLE
Support non-existing proofs in RwTable

### DIFF
--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -204,6 +204,7 @@ class AccountFieldTag(IntEnum):
     Nonce = auto()
     Balance = auto()
     CodeHash = auto()
+    NonExisting = auto()
 
 
 class CallContextFieldTag(IntEnum):
@@ -312,20 +313,25 @@ class MPTProofType(IntEnum):
     Tag for MPT lookup.
     """
 
-    StorageMod = 0
     NonceMod = 1
     BalanceMod = 2
     CodeHashMod = 3
-    AccountDeleteMod = 4
-    NonExistingAccountProof = 5
+    NonExistingAccountProof = 4
+    AccountDeleteMod = 5
+    StorageMod = 6
+    NonExistingStorageProof = 7
 
     @staticmethod
     def from_account_field_tag(field_tag: AccountFieldTag) -> MPTProofType:
+        if field_tag == AccountFieldTag.Nonce:
+            return MPTProofType.NonceMod
         if field_tag == AccountFieldTag.Balance:
             return MPTProofType.BalanceMod
         elif field_tag == AccountFieldTag.CodeHash:
             return MPTProofType.CodeHashMod
-        return MPTProofType.NonceMod
+        elif field_tag == AccountFieldTag.NonExisting:
+            return MPTProofType.NonExistingAccountProof
+        raise Exception("Unexpected AccountFieldTag value")
 
 
 class WrongQueryKey(Exception):

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -236,11 +236,14 @@ def check_storage(row: Row, row_prev: Row, row_next: Row, tables: Tables):
     # 4.0. Unused keys are 0
     assert row.field_tag() == 0
 
+    is_non_exist = FQ(row.value.expr() == FQ(0)) * FQ(row.committed_value.expr() == FQ(0))
+
     # 4.1. MPT lookup for last access to (address, storage_key)
     if not all_keys_eq(row, row_next):
         tables.mpt_lookup(
             row.address(),
-            FQ(MPTProofType.StorageMod),
+            is_non_exist * FQ(MPTProofType.NonExistingStorageProof)
+            + (1 - is_non_exist) * FQ(MPTProofType.StorageMod),
             row.storage_key(),
             row.value,
             row.committed_value,


### PR DESCRIPTION
- Add AccountFieldType.NonExisting in order to perform lookups from the EVM circuit that use non-existing proofs (for accounts) from the MPT Circuit via the State circuit.
- Add MPTProofType.NonExistingStorageProof so that the MPT Circuit can prove non-existence of storage keys.
- Update State Circuit to transparently use MPTProofType.NonExistingStorageProof for Storage entries when  the MPT Lookup has committedValue == 0 and value == 0.

The change that makes the State Circuit support non-existing proofs on the Storage Tag will require 2 IsZero gadgets (which require a column each).  I'm not sure if there is any free column to be reused on Storage rows in the State Circuit, or 2 new columns need to be allocated.
I believe non-existence storage proofs support can be handled in 3 different ways:
- a.  Add a new `RwTable` field called `NonExistenceStorage`.  Require all EVM circuits that perform storage read/writes to check if the proof is of non-existence (by adding 1 or 2 IsZero gadgets, depending on whether it's read or write).  Then conditionally lookup to RwTable with `NonExistenceStorage` or `Storage.
- b.  Transparently support Storage rows that require non-existence proofs via the RwTable.  Let the StateCircuit figure out if the MPT lookup must be `Storage` or `NonExistenceStorage` by checking if value and valuePrev are 0 (with 2 IsZero gadgets)
- c. Add support for Storage modifications where valuePrev and value are 0 in the MPT Circuit.

In https://github.com/privacy-scaling-explorations/zkevm-specs/issues/249 we discussed not doing option (c).  I think option (b) is the best because it's transparent to the EVM Circuit, and also allows merging changes (for example, for an address and key there's a read where value=0, and then a write where value=v, the state circuit only performs 1 MPT lookup).
@z2trillion what do you think about this?

Resolve https://github.com/privacy-scaling-explorations/zkevm-specs/issues/249