### PR TITLE
Fix bad indentation in the `EXP` spec doc

### DIFF
--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -44,33 +44,33 @@ The exponentiation circuit consists of the following columns:
     - Since we are only performing multiplication with the equation `a * b + c == d`, `c` in the `mul_gadget` MUST equal `0`.
     - Since we are performing `2 * q + r == exponent` in the `parity_check` multiplication gadget, `r` is boolean, that is:
         - `r_hi` MUST equal `0`.
-	- `r_lo` MUST be boolean.
-	- `overflow` in the `parity_check` MUST equal `0`.
+        - `r_lo` MUST be boolean.
+        - `overflow` in the `parity_check` MUST equal `0`.
     - If parity check is `odd`, i.e. `parity_check.r_lo == 1`:
         - `exponent` MUST reduce by 1, which means:
-	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `exponent::cur - 1`.
-	    - High 128 bits of `exponent::next` MUST equal high 128 bits of `exponent::cur`.
+            - Low 128 bits of `exponent::next` MUST equal low 128 bits of `exponent::cur - 1`.
+            - High 128 bits of `exponent::next` MUST equal high 128 bits of `exponent::cur`.
         - `exponent` is odd also means it was a multiplication by `base` operation, that is:
             - For each limb, `exp_table.base_limb == mul_gadget.b`.
     - If parity check if `even`, i.e. `parity_check.r_lo == 0`:
         - `exponent` MUST reduce to `exponent // 2`, which means:
-	    - Low 128 bits of `exponent::cur` MUST equal low 128 bits of `parity_check`'s multiplication result `d`.
-	        - That is, `exp_table.exponent_lo == parity_check.d_lo`.
-	    - High 128 bits of `exponent::cur` MUST equal high 128 bits of `parity_check`'s multiplication result `d`.
-	        - That is, `exp_table.exponent_hi == parity_check.d_hi`.
-	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `parity_check`'s multiplicand `q`.
-	        - That is, `exp_table.exponent_lo::next == parity_check.q_lo`. We compute `q_lo` using the 64-bit limbs of `q`.
-	    - High 128 bits of `exponent::next` MUST equal high 128 bits of `parity_check`'s multiplicand `q`.
-	        - That is, `exp_table.exponent_hi::next == parity_check.q_hi`. We compute `q_hi` using the 64-bit limbs of `q`.
-	- `exponent` is even also means it was a squaring operation, that is:
-	    - `mul_gadget`'s multiplicands MUST be equal, or, `mul_gadget.a == mul_gadget.b`.
-    - For the last step, i.e. `is_last == true`, validate that `a * a == a^2 (mod 2^256)`:
-        - `exponent` MUST equal `2`, that is:
-	    - `exp_table.exponent_lo == 2`
-	    - `exp_table.exponent_hi == 0`
-	- Both multiplicand's of the `mul_gadget`, i.e. `a` and `b` MUST equal `base` of the exponentiation operation, that is:
-	    - `mul_gadget.a == base`
-	    - `mul_gadget.b == base` (for both these cases we equate each 64-bit limb)
+            - Low 128 bits of `exponent::cur` MUST equal low 128 bits of `parity_check`'s multiplication result `d`.
+                - That is, `exp_table.exponent_lo == parity_check.d_lo`.
+            - High 128 bits of `exponent::cur` MUST equal high 128 bits of `parity_check`'s multiplication result `d`.
+                - That is, `exp_table.exponent_hi == parity_check.d_hi`.
+            - Low 128 bits of `exponent::next` MUST equal low 128 bits of `parity_check`'s multiplicand `q`.
+                - That is, `exp_table.exponent_lo::next == parity_check.q_lo`. We compute `q_lo` using the 64-bit limbs of `q`.
+            - High 128 bits of `exponent::next` MUST equal high 128 bits of `parity_check`'s multiplicand `q`.
+                - That is, `exp_table.exponent_hi::next == parity_check.q_hi`. We compute `q_hi` using the 64-bit limbs of `q`.
+        - `exponent` is even also means it was a squaring operation, that is:
+            - `mul_gadget`'s multiplicands MUST be equal, or, `mul_gadget.a == mul_gadget.b`.
+- For the last step, i.e. `is_last == true`, validate that `a * a == a^2 (mod 2^256)`:
+    - `exponent` MUST equal `2`, that is:
+        - `exp_table.exponent_lo == 2`
+        - `exp_table.exponent_hi == 0`
+    - Both multiplicand's of the `mul_gadget`, i.e. `a` and `b` MUST equal `base` of the exponentiation operation, that is:
+        - `mul_gadget.a == base`
+        - `mul_gadget.b == base` (for both these cases we equate each 64-bit limb)
 
 ## Code
 

--- a/specs/exp-proof.md
+++ b/specs/exp-proof.md
@@ -50,8 +50,8 @@ The exponentiation circuit consists of the following columns:
         - `exponent` MUST reduce by 1, which means:
 	    - Low 128 bits of `exponent::next` MUST equal low 128 bits of `exponent::cur - 1`.
 	    - High 128 bits of `exponent::next` MUST equal high 128 bits of `exponent::cur`.
-	- `exponent` is odd also means it was a multiplication by `base` operation, that is:
-	    - For each limb, `exp_table.base_limb == mul_gadget.b`.
+        - `exponent` is odd also means it was a multiplication by `base` operation, that is:
+            - For each limb, `exp_table.base_limb == mul_gadget.b`.
     - If parity check if `even`, i.e. `parity_check.r_lo == 0`:
         - `exponent` MUST reduce to `exponent // 2`, which means:
 	    - Low 128 bits of `exponent::cur` MUST equal low 128 bits of `parity_check`'s multiplication result `d`.


### PR DESCRIPTION
Changed tab for space, fixed bullet indentation