### PR TITLE
fix: make exp gadget compatible with circuits impl

### DIFF
--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -13,10 +13,13 @@ def exp(instruction: Instruction):
     exponent_lo, exponent_hi = instruction.word_to_lo_hi(exponent_rlc)
     exponentiation_lo, exponentiation_hi = instruction.word_to_lo_hi(exponentiation_rlc)
 
-    if instruction.is_zero(exponent_rlc) == FQ.one():
+    exponent_is_zero = instruction.is_zero(exponent_hi) * instruction.is_zero(exponent_lo)
+    exponent_is_one = instruction.is_zero(exponent_hi) * instruction.is_equal(exponent_lo, FQ.one())
+
+    if exponent_is_zero == FQ.one():
         instruction.constrain_equal(exponentiation_lo, FQ.one())
         instruction.constrain_zero(exponentiation_hi)
-    elif instruction.is_equal(exponent_rlc, FQ.one()) == FQ.one():
+    elif exponent_is_one == FQ.one():
         instruction.constrain_equal(exponentiation_lo, base_lo)
         instruction.constrain_equal(exponentiation_hi, base_hi)
     else:

--- a/src/zkevm_specs/evm/execution/exp.py
+++ b/src/zkevm_specs/evm/execution/exp.py
@@ -25,7 +25,7 @@ def exp(instruction: Instruction):
     else:
         base_limbs = instruction.word_to_64s(base_rlc)
         identifier = FQ(instruction.curr.rw_counter + instruction.rw_counter_offset)
-        single_step = instruction.is_equal(exponent_rlc, FQ(2))
+        single_step = instruction.is_zero(exponent_hi) * instruction.is_equal(exponent_lo, FQ(2))
 
         # lookup to enforce the is_first step
         res_lo, res_hi = instruction.exp_lookup(


### PR DESCRIPTION
We define a boolean variable `single_step` where:
- `single_step == 1 if exponent == 2`
- `single_step == 0 if exponent > 2`

We don't need any additional constraints on `single_step` (not even `require_boolean`) because it is simply used to do a lookup to the exponentiation circuit. All necessary constraints on that column (`exp_circuit.exp_table.is_last`) are handled within the exponentiation circuit.

This makes the [specs gadget](https://github.com/scroll-tech/zkevm-specs/blob/fix/exp-circuit-compat/src/zkevm_specs/evm/execution/exp.py#L25-L34) compatible with the [circuits gadget](https://github.com/scroll-tech/zkevm-circuits/blob/feat/exp/zkevm-circuits/src/evm_circuit/execution/exp.rs#L130-L167)

@adria0 This is the last pending PR before we can get https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/700 merged