### PR TITLE
Update `BeginTx`

### DIFF
--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -10,9 +10,12 @@ def begin_tx(instruction: Instruction):
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=call_id)
     reversion_info = instruction.reversion_info(call_id=call_id)
+    instruction.constrain_equal(
+        instruction.call_context_lookup(CallContextFieldTag.IsSuccess, call_id=call_id),
+        reversion_info.is_persistent,
+    )
 
     if instruction.is_first_step:
-        instruction.constrain_equal(instruction.curr.rw_counter, FQ(1))
         instruction.constrain_equal(tx_id, FQ(1))
 
     tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
@@ -82,7 +85,7 @@ def begin_tx(instruction: Instruction):
             # Do step state transition
             instruction.constrain_equal(instruction.next.execution_state, ExecutionState.EndTx)
             instruction.constrain_step_state_transition(
-                rw_counter=Transition.delta(9), call_id=Transition.to(call_id)
+                rw_counter=Transition.delta(10), call_id=Transition.to(call_id)
             )
         else:
 
@@ -112,7 +115,7 @@ def begin_tx(instruction: Instruction):
                 )
 
             instruction.step_state_transition_to_new_context(
-                rw_counter=Transition.delta(22),
+                rw_counter=Transition.delta(23),
                 call_id=Transition.to(call_id),
                 is_root=Transition.to(True),
                 is_create=Transition.to(False),

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -40,6 +40,7 @@ def verify_step(instruction: Instruction):
             instruction.curr.execution_state,
             [FQ(ExecutionState.BeginTx), FQ(ExecutionState.EndBlock)],
         )
+        instruction.constrain_equal(instruction.curr.rw_counter, FQ(1))
 
     if instruction.is_last_step:
         instruction.constrain_equal(instruction.curr.execution_state, ExecutionState.EndBlock)

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -96,7 +96,7 @@ TESTING_DATA = (
 def test_begin_tx(tx: Transaction, callee: Account, is_success: bool):
     randomness = rand_fq()
 
-    rw_counter_end_of_reversion = 23
+    rw_counter_end_of_reversion = 24
     caller_balance_prev = int(1e20)
     callee_balance_prev = callee.balance
     caller_balance = caller_balance_prev - (tx.value + tx.gas * tx.gas_price)
@@ -110,6 +110,7 @@ def test_begin_tx(tx: Transaction, callee: Account, is_success: bool):
         .call_context_read(1, CallContextFieldTag.TxId, tx.id)
         .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_success else rw_counter_end_of_reversion)
         .call_context_read(1, CallContextFieldTag.IsPersistent, is_success)
+        .call_context_read(1, CallContextFieldTag.IsSuccess, is_success)
         .account_write(tx.caller_address, AccountFieldTag.Nonce, tx.nonce + 1, tx.nonce)
         .tx_access_list_account_write(tx.id, tx.caller_address, True, False)
         .tx_access_list_account_write(tx.id, tx.callee_address, True, False)

--- a/tests/test_public_inputs.py
+++ b/tests/test_public_inputs.py
@@ -1,10 +1,13 @@
-import traceback
-from typing import Union, List, Callable
-from eth_keys import keys
-from eth_utils import keccak
-import rlp
-from zkevm_specs.public_inputs import *
-from zkevm_specs.util import FQ, RLC, U64, U256, U160
+from typing import Union, Callable
+from zkevm_specs.public_inputs import (
+    Witness,
+    PublicData,
+    public_data2witness,
+    verify_circuit,
+    Block,
+    Transaction,
+)
+from zkevm_specs.util import FQ, U64, U256, U160
 import random
 from random import randrange, randbytes
 
@@ -118,7 +121,7 @@ def test_basic():
     verify(public_data, MAX_TXS, MAX_CALLDATA_BYTES, rand_rpi)
 
 
-def override_not_success(override: Callable[Witness, None]):
+def override_not_success(override: Callable[[Witness], None]):
     random.seed(0)
 
     MAX_TXS = 2
@@ -196,13 +199,6 @@ def test_bad_rand_rpi_chain_id_pub():
 def test_bad_rand_rpi_state_root_pub():
     def override(witness):
         witness.public_inputs.state_root = FQ(123)
-
-    override_not_success(override)
-
-
-def test_bad_rand_rpi_state_root_prev_pub():
-    def override(witness):
-        witness.public_inputs.state_root_prev = FQ(123)
 
     override_not_success(override)
 


### PR DESCRIPTION
This PR aims to synchronize `BeginTx` to current circuit implementation with an extra `IsSuccess` call context write lookup.

It also fix `test_public_inputs.py` to have correct type and remove duplicated test (not sure why my `make test` fails with the wrong type definition but CI doesn't).