### PR TITLE
Fix opcode `EXTCODEHASH` to use non-existing proof for account existence

### DIFF
--- a/specs/opcode/3fEXTCODEHASH.md
+++ b/specs/opcode/3fEXTCODEHASH.md
@@ -3,33 +3,31 @@
 ## Procedure
 
 The `EXTCODEHASH` opcode pops `address` off the stack and pushes the code hash
-of the corresponding account onto the stack. If the corresponding account is
-empty (i.e. has nonce = 0, balance = 0 and no code), then it will push 0 onto
-the stack instead.
+of the corresponding account onto the stack. If the corresponding account
+doesn't exist (by checking non existing flag), then it will push 0 onto the
+stack instead.
 
 ## Constraints
 
 1. opId = 0x3f
 2. State transition:
-   - gc + 9 (1 stack read, 1 stack write, 3 call context reads, 3 account reads,
+   - gc + 7 (1 stack read, 1 stack write, 3 call context reads, 1 account read,
      1 transaction access list write)
    - stack_pointer + 0 (one pop and one push)
    - pc + 1
    - gas:
      - the accessed `address` is warm: WARM_STORAGE_READ_COST
      - the accessed `address` is cold: COLD_ACCOUNT_ACCESS_COST
-3. Lookups: 9
+3. Lookups: 7 busmapping lookups
    - `address` is popped from the stack
    - 3 from call context for `tx_id`, `rw_counter_end_of_reversion`, and
      `is_persistent`.
-   - `address` is added to the transaction access list if not already present
-   - nonce of account is `nonce`
-   - balance of account is `balance`
-   - code hash of account is `code_hash`
-   - if the account is (non)empty, (`code_hash`) 0 is pushed onto the stack
+   - `address` is added to the transaction access list if not already present.
+   - If witness value `exists == 1`, lookup account `code_hash`. Otherwise
+     lookup account non-existing proof.
+   - The EXTCODEHASH result is at the new top of the stack.
 4. Additional Constraints
-   - value `is_warm` matches the gas cost for this opcode
-   - `is_empty` is boolean and 1 iff the account is empty
+   - value `is_warm` matches the gas cost for this opcode.
 
 ## Exceptions
 

--- a/src/zkevm_specs/evm/execution/balance.py
+++ b/src/zkevm_specs/evm/execution/balance.py
@@ -1,4 +1,4 @@
-from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS, RLC
+from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import AccountFieldTag, CallContextFieldTag
@@ -16,10 +16,11 @@ def balance(instruction: Instruction):
     # Load account `exists` value from auxilary witness data.
     exists = instruction.curr.aux_data
 
-    if exists == 0:  # 1 - exists == 1
+    if exists == 1:
+        balance = instruction.account_read(address, AccountFieldTag.Balance)
+    else:  # exists == 0
         instruction.account_read(address, AccountFieldTag.NonExisting)
 
-    balance = instruction.account_read(address, AccountFieldTag.Balance) if exists == 1 else RLC(0)
     instruction.constrain_equal(
         instruction.select(exists, balance.expr(), FQ(0)),
         instruction.stack_push(),

--- a/src/zkevm_specs/evm/execution/balance.py
+++ b/src/zkevm_specs/evm/execution/balance.py
@@ -1,4 +1,4 @@
-from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
+from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS, RLC
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import AccountFieldTag, CallContextFieldTag
@@ -16,10 +16,10 @@ def balance(instruction: Instruction):
     # Load account `exists` value from auxilary witness data.
     exists = instruction.curr.aux_data
 
-    if exists == 1:
-        balance = instruction.account_read(address, AccountFieldTag.Balance)
-    else:  # exists == 0
+    if exists == 0:
         instruction.account_read(address, AccountFieldTag.NonExisting)
+
+    balance = instruction.account_read(address, AccountFieldTag.Balance) if exists == 1 else RLC(0)
 
     instruction.constrain_equal(
         instruction.select(exists, balance.expr(), FQ(0)),

--- a/src/zkevm_specs/evm/execution/extcodehash.py
+++ b/src/zkevm_specs/evm/execution/extcodehash.py
@@ -1,4 +1,4 @@
-from ...util import EMPTY_CODE_HASH, EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
+from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import AccountFieldTag, CallContextFieldTag
@@ -16,14 +16,11 @@ def extcodehash(instruction: Instruction):
     # Load account `exists` value from auxilary witness data.
     exists = instruction.curr.aux_data
 
-    if exists == 0:  # 1 - exists == 1
+    if exists == 1:
+        code_hash = instruction.account_read(address, AccountFieldTag.CodeHash)
+    else:  # exists == 0
         instruction.account_read(address, AccountFieldTag.NonExisting)
 
-    code_hash = (
-        instruction.account_read(address, AccountFieldTag.CodeHash)
-        if exists == 1
-        else instruction.rlc_encode(EMPTY_CODE_HASH, 32)
-    )
     instruction.constrain_equal(
         instruction.select(exists, code_hash.expr(), FQ(0)),
         instruction.stack_push(),

--- a/src/zkevm_specs/evm/execution/extcodehash.py
+++ b/src/zkevm_specs/evm/execution/extcodehash.py
@@ -1,37 +1,38 @@
+from ...util import EMPTY_CODE_HASH, EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
-from ..table import CallContextFieldTag, AccountFieldTag
-from ...util.param import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS
-from ...util.hash import EMPTY_CODE_HASH
-from ...util import FQ
+from ..opcode import Opcode
+from ..table import AccountFieldTag, CallContextFieldTag
 
 
 def extcodehash(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
+    instruction.constrain_equal(opcode, Opcode.EXTCODEHASH)
 
-    address = instruction.rlc_to_fq(instruction.stack_pop(), 20)
+    address = instruction.rlc_to_fq(instruction.stack_pop(), N_BYTES_ACCOUNT_ADDRESS)
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
     is_warm = instruction.add_account_to_access_list(tx_id, address, instruction.reversion_info())
 
-    nonce = instruction.account_read(address, AccountFieldTag.Nonce)
-    balance = instruction.account_read(address, AccountFieldTag.Balance)
-    code_hash = instruction.account_read(address, AccountFieldTag.CodeHash)
+    # Load account `exists` value from auxilary witness data.
+    exists = instruction.curr.aux_data
 
-    is_empty = (
-        instruction.is_zero(nonce)
-        * instruction.is_zero(balance)
-        * instruction.is_equal(code_hash, instruction.rlc_encode(EMPTY_CODE_HASH, 32))
+    if exists == 0:  # 1 - exists == 1
+        instruction.account_read(address, AccountFieldTag.NonExisting)
+
+    code_hash = (
+        instruction.account_read(address, AccountFieldTag.CodeHash)
+        if exists == 1
+        else instruction.rlc_encode(EMPTY_CODE_HASH, 32)
     )
-
     instruction.constrain_equal(
-        instruction.select(is_empty, FQ(0), code_hash.expr()),
+        instruction.select(exists, code_hash.expr(), FQ(0)),
         instruction.stack_push(),
     )
 
     instruction.step_state_transition_in_same_context(
         opcode,
-        rw_counter=Transition.delta(9),
+        rw_counter=Transition.delta(7),
         program_counter=Transition.delta(1),
-        stack_pointer=Transition.delta(0),
+        stack_pointer=Transition.same(),
         dynamic_gas_cost=instruction.select(is_warm, FQ(0), FQ(EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS)),
     )

--- a/src/zkevm_specs/evm/execution/extcodehash.py
+++ b/src/zkevm_specs/evm/execution/extcodehash.py
@@ -1,4 +1,4 @@
-from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS
+from ...util import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, FQ, N_BYTES_ACCOUNT_ADDRESS, RLC
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import AccountFieldTag, CallContextFieldTag
@@ -16,10 +16,12 @@ def extcodehash(instruction: Instruction):
     # Load account `exists` value from auxilary witness data.
     exists = instruction.curr.aux_data
 
-    if exists == 1:
-        code_hash = instruction.account_read(address, AccountFieldTag.CodeHash)
-    else:  # exists == 0
+    if exists == 0:
         instruction.account_read(address, AccountFieldTag.NonExisting)
+
+    code_hash = (
+        instruction.account_read(address, AccountFieldTag.CodeHash) if exists == 1 else RLC(0)
+    )
 
     instruction.constrain_equal(
         instruction.select(exists, code_hash.expr(), FQ(0)),

--- a/tests/evm/test_balance.py
+++ b/tests/evm/test_balance.py
@@ -55,8 +55,8 @@ def test_balance(address: U160, balance: U256, exists: int, is_warm: bool, is_pe
     tx_id = 1
     call_id = 1
 
-    # 9 + 1 reversible operation (the account access list write)
-    rw_counter_end_of_reversion = 0 if is_persistent else 10
+    # 7 + 1 reversible operation (the account access list write)
+    rw_counter_end_of_reversion = 0 if is_persistent else 8
     reversible_write_counter = 0
 
     rw_dictionary = (

--- a/tests/evm/test_extcodehash.py
+++ b/tests/evm/test_extcodehash.py
@@ -1,74 +1,69 @@
 import pytest
 
 from zkevm_specs.evm import (
-    ExecutionState,
-    StepState,
-    verify_steps,
-    Tables,
-    RWTableTag,
-    RW,
+    AccountFieldTag,
     Block,
     Bytecode,
     CallContextFieldTag,
-    AccountFieldTag,
+    ExecutionState,
     RWDictionary,
+    StepState,
+    Tables,
+    verify_steps,
 )
 from zkevm_specs.util import (
+    EMPTY_CODE_HASH,
+    EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS,
+    GAS_COST_WARM_ACCESS,
+    RLC,
+    U160,
+    U256,
+    keccak256,
     rand_address,
+    rand_bytes,
+    rand_fq,
     rand_range,
     rand_word,
-    rand_fq,
-    U256,
-    U160,
-    keccak256,
-    RLC,
-    rand_bytes,
 )
-from zkevm_specs.util.param import EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS, GAS_COST_WARM_ACCESS
-from zkevm_specs.util.hash import EMPTY_CODE_HASH
-
 
 TESTING_DATA = [
-    (0x30000, 0, 0, bytes(), True, True),  # warm empty account
-    (0x30000, 0, 0, bytes(), False, True),  # cold empty account
-    (0x30000, 1, 200, bytes([10, 40]), True, True),  # warm non-empty account
-    (0x30000, 1, 200, bytes([10, 10]), False, True),  # cold non-empty account
-    (0x30000, 1, 0, bytes(), False, True),  # non-empty account because of nonce
+    (0x30000, bytes(), 0, True, True),  # warm empty account
+    (0x30000, bytes(), 0, False, True),  # cold empty account
+    (0x30000, bytes([10, 40]), 1, True, True),  # warm non-empty account
+    (0x30000, bytes([10, 10]), 1, False, True),  # cold non-empty account
+    (0x30000, bytes(), 1, False, True),  # non-empty account with empty code
     (
         rand_address(),
-        rand_word(),
-        rand_word(),
         rand_bytes(100),
+        rand_range(2),
         rand_range(2) == 0,
         True,  # persistent call
     ),
     (
         rand_address(),
-        rand_word(),
-        rand_word(),
         rand_bytes(100),
+        rand_range(2),
         rand_range(2) == 0,
         False,  # reverted call
     ),
 ]
 
 
-@pytest.mark.parametrize("address, nonce, balance, code, is_warm, is_persistent", TESTING_DATA)
-def test_extcodehash(
-    address: U160, nonce: U256, balance: U256, code: bytes, is_warm: bool, is_persistent: bool
-):
+@pytest.mark.parametrize("address, code, exists, is_warm, is_persistent", TESTING_DATA)
+def test_extcodehash(address: U160, code: bytes, exists: int, is_warm: bool, is_persistent: bool):
     randomness = rand_fq()
 
     code_hash = int.from_bytes(keccak256(code), "big")
-    result = 0 if (nonce == 0 and balance == 0 and code_hash == EMPTY_CODE_HASH) else code_hash
+    result = code_hash if exists == 1 else 0
 
     tx_id = 1
     call_id = 1
 
-    rw_counter_end_of_reversion = 0 if is_persistent else 9
+    # 9 + 1 reversible operation (the account access list write)
+    rw_counter_end_of_reversion = 0 if is_persistent else 10
     reversible_write_counter = 0
 
-    rw_table = set(
+    rw_dictionary = (
         RWDictionary(1)
         .stack_read(call_id, 1023, RLC(address, randomness))
         .call_context_read(tx_id, CallContextFieldTag.TxId, tx_id)
@@ -83,12 +78,15 @@ def test_extcodehash(
             is_warm,
             rw_counter_of_reversion=rw_counter_end_of_reversion - reversible_write_counter,
         )
-        .account_read(address, AccountFieldTag.Nonce, RLC(nonce, randomness))
-        .account_read(address, AccountFieldTag.Balance, RLC(balance, randomness))
-        .account_read(address, AccountFieldTag.CodeHash, RLC(code_hash, randomness))
-        .stack_write(call_id, 1023, RLC(result, randomness))
-        .rws
     )
+    if exists == 1:
+        rw_dictionary.account_read(address, AccountFieldTag.CodeHash, RLC(code_hash, randomness))
+    else:
+        rw_dictionary.account_read(
+            address, AccountFieldTag.NonExisting, RLC(1 - exists, randomness)
+        )
+
+    rw_table = set(rw_dictionary.stack_write(call_id, 1023, RLC(result, randomness)).rws)
 
     bytecode = Bytecode().extcodehash()
     tables = Tables(
@@ -113,10 +111,11 @@ def test_extcodehash(
                 program_counter=0,
                 stack_pointer=1023,
                 gas_left=GAS_COST_WARM_ACCESS + (not is_warm) * EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS,
+                aux_data=exists,
             ),
             StepState(
                 execution_state=ExecutionState.STOP if is_persistent else ExecutionState.REVERT,
-                rw_counter=10,
+                rw_counter=8,
                 call_id=1,
                 is_root=True,
                 is_create=False,

--- a/tests/evm/test_extcodehash.py
+++ b/tests/evm/test_extcodehash.py
@@ -59,8 +59,8 @@ def test_extcodehash(address: U160, code: bytes, exists: int, is_warm: bool, is_
     tx_id = 1
     call_id = 1
 
-    # 9 + 1 reversible operation (the account access list write)
-    rw_counter_end_of_reversion = 0 if is_persistent else 10
+    # 7 + 1 reversible operation (the account access list write)
+    rw_counter_end_of_reversion = 0 if is_persistent else 8
     reversible_write_counter = 0
 
     rw_dictionary = (


### PR DESCRIPTION
According to previous `BALANCE` PR https://github.com/privacy-scaling-explorations/zkevm-specs/pull/248, fix this opcode to use non-existing proof for account existence check.