### PR TITLE
fix `no_implicit_optional` in CI

### DIFF
--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -440,7 +440,7 @@ class Instruction:
 
         return fq
 
-    def rlc_encode(self, value: Union[FQ, int, bytes], n_bytes: int = None) -> RLC:
+    def rlc_encode(self, value: Union[FQ, int, bytes], n_bytes: Optional[int] = None) -> RLC:
         if isinstance(value, FQ):
             value = value.n
         if isinstance(value, bytes):
@@ -671,7 +671,7 @@ class Instruction:
 
     # look up byte code value
     def bytecode_lookup(
-        self, bytecode_hash: Expression, index: Expression, is_code: Expression = None
+        self, bytecode_hash: Expression, index: Expression, is_code: Optional[Expression] = None
     ) -> Expression:
         return self.tables.bytecode_lookup(
             bytecode_hash, FQ(BytecodeFieldTag.Byte), index, is_code
@@ -712,14 +712,14 @@ class Instruction:
         self,
         rw: RW,
         tag: RWTableTag,
-        key1: Expression = None,
-        key2: Expression = None,
-        key3: Expression = None,
-        key4: Expression = None,
-        value: Expression = None,
-        value_prev: Expression = None,
-        aux0: Expression = None,
-        rw_counter: Expression = None,
+        key1: Optional[Expression] = None,
+        key2: Optional[Expression] = None,
+        key3: Optional[Expression] = None,
+        key4: Optional[Expression] = None,
+        value: Optional[Expression] = None,
+        value_prev: Optional[Expression] = None,
+        aux0: Optional[Expression] = None,
+        rw_counter: Optional[Expression] = None,
     ) -> RWTableRow:
         if rw_counter is None:
             rw_counter = self.curr.rw_counter + self.rw_counter_offset
@@ -741,14 +741,14 @@ class Instruction:
     def state_write(
         self,
         tag: RWTableTag,
-        key1: Expression = None,
-        key2: Expression = None,
-        key3: Expression = None,
-        key4: Expression = None,
-        value: Expression = None,
-        value_prev: Expression = None,
-        aux0: Expression = None,
-        reversion_info: ReversionInfo = None,
+        key1: Optional[Expression] = None,
+        key2: Optional[Expression] = None,
+        key3: Optional[Expression] = None,
+        key4: Optional[Expression] = None,
+        value: Optional[Expression] = None,
+        value_prev: Optional[Expression] = None,
+        aux0: Optional[Expression] = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> RWTableRow:
         assert tag.write_with_reversion()
 
@@ -772,7 +772,7 @@ class Instruction:
         return row
 
     def call_context_lookup(
-        self, field_tag: CallContextFieldTag, rw: RW = RW.Read, call_id: Expression = None
+        self, field_tag: CallContextFieldTag, rw: RW = RW.Read, call_id: Optional[Expression] = None
     ) -> Expression:
         if call_id is None:
             call_id = self.curr.call_id
@@ -782,7 +782,7 @@ class Instruction:
         # Raises exception if no lookup matches
         self.rw_lookup(rw=RW.Read, tag=RWTableTag.Start, rw_counter=counter)
 
-    def reversion_info(self, call_id: Expression = None) -> ReversionInfo:
+    def reversion_info(self, call_id: Optional[Expression] = None) -> ReversionInfo:
         [rw_counter_end_of_reversion, is_persistent] = [
             self.call_context_lookup(tag, call_id=call_id)
             for tag in [
@@ -811,7 +811,7 @@ class Instruction:
             self.rw_lookup(rw, RWTableTag.Stack, self.curr.call_id, stack_pointer).value, RLC
         )
 
-    def memory_write(self, memory_address: Expression, call_id: Expression = None) -> FQ:
+    def memory_write(self, memory_address: Expression, call_id: Optional[Expression] = None) -> FQ:
         return self.memory_lookup(RW.Write, memory_address, call_id)
 
     def memory_read(
@@ -819,7 +819,9 @@ class Instruction:
     ) -> Expression:
         return self.memory_lookup(RW.Read, memory_address, call_id)
 
-    def memory_lookup(self, rw: RW, memory_address: Expression, call_id: Expression = None) -> FQ:
+    def memory_lookup(
+        self, rw: RW, memory_address: Expression, call_id: Optional[Expression] = None
+    ) -> FQ:
         if call_id is None:
             call_id = self.curr.call_id
         return cast_expr(self.rw_lookup(rw, RWTableTag.Memory, call_id, memory_address).value, FQ)
@@ -830,7 +832,7 @@ class Instruction:
     def tx_refund_write(
         self,
         tx_id: Expression,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[FQ, FQ]:
         row = self.state_write(
             RWTableTag.TxRefund,
@@ -851,7 +853,7 @@ class Instruction:
         self,
         account_address: Expression,
         account_field_tag: AccountFieldTag,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[Expression, Expression]:
         row = self.state_write(
             RWTableTag.Account,
@@ -865,7 +867,7 @@ class Instruction:
         self,
         account_address: Expression,
         values: Sequence[RLC],
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[RLC, RLC]:
         value, value_prev = self.account_write(
             account_address, AccountFieldTag.Balance, reversion_info
@@ -880,7 +882,7 @@ class Instruction:
         self,
         account_address: Expression,
         values: Sequence[RLC],
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[RLC, RLC]:
         value, value_prev = self.account_write(
             account_address, AccountFieldTag.Balance, reversion_info
@@ -909,7 +911,7 @@ class Instruction:
         account_address: Expression,
         storage_key: Expression,
         tx_id: Expression,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[RLC, RLC, RLC]:
         row = self.state_write(
             RWTableTag.AccountStorage,
@@ -922,7 +924,10 @@ class Instruction:
         return cast_expr(row.value, RLC), cast_expr(row.value_prev, RLC), cast_expr(row.aux0, RLC)
 
     def add_account_to_access_list(
-        self, tx_id: Expression, account_address: Expression, reversion_info: ReversionInfo = None
+        self,
+        tx_id: Expression,
+        account_address: Expression,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> FQ:
         row = self.state_write(
             RWTableTag.TxAccessListAccount,
@@ -938,7 +943,7 @@ class Instruction:
         tx_id: Expression,
         account_address: Expression,
         storage_key: Expression,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> FQ:
         row = self.state_write(
             RWTableTag.TxAccessListAccountStorage,
@@ -956,7 +961,7 @@ class Instruction:
         receiver_address: Expression,
         value: RLC,
         gas_fee: RLC,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[Tuple[RLC, RLC], Tuple[RLC, RLC]]:
         sender_balance_pair = self.sub_balance(sender_address, [value, gas_fee], reversion_info)
         receiver_balance_pair = self.add_balance(receiver_address, [value], reversion_info)
@@ -967,7 +972,7 @@ class Instruction:
         sender_address: Expression,
         receiver_address: Expression,
         value: RLC,
-        reversion_info: ReversionInfo = None,
+        reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[Tuple[RLC, RLC], Tuple[RLC, RLC]]:
         sender_balance_pair = self.sub_balance(sender_address, [value], reversion_info)
         receiver_balance_pair = self.add_balance(receiver_address, [value], reversion_info)
@@ -1053,7 +1058,7 @@ class Instruction:
         dst_addr: Expression,
         length: Expression,
         rw_counter: Expression,
-        log_id: Expression = None,
+        log_id: Optional[Expression] = None,
     ) -> Tuple[FQ, FQ]:
         copy_table_row = self.tables.copy_lookup(
             src_id,

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Optional, Any
 from .execution_state import ExecutionState
 from ..util import FQ, RLC
 
@@ -58,7 +58,7 @@ class StepState:
         memory_size: int = 0,
         reversible_write_counter: int = 0,
         log_id: int = 0,
-        aux_data: Any = None,
+        aux_data: Optional[Any] = None,
     ) -> None:
         self.execution_state = execution_state
         self.rw_counter = FQ(rw_counter)

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -523,9 +523,9 @@ class Tables:
         tx_table: Set[TxTableRow],
         bytecode_table: Set[BytecodeTableRow],
         rw_table: Union[Set[Sequence[Expression]], Set[RWTableRow]],
-        copy_circuit: Sequence[CopyCircuitRow] = None,
-        keccak_table: Sequence[KeccakTableRow] = None,
-        exp_circuit: Sequence[ExpCircuitRow] = None,
+        copy_circuit: Optional[Sequence[CopyCircuitRow]] = None,
+        keccak_table: Optional[Sequence[KeccakTableRow]] = None,
+        exp_circuit: Optional[Sequence[ExpCircuitRow]] = None,
     ) -> None:
         self.block_table = block_table
         self.tx_table = tx_table
@@ -629,7 +629,7 @@ class Tables:
         bytecode_hash: Expression,
         field_tag: Expression,
         index: Expression,
-        is_code: Expression = None,
+        is_code: Optional[Expression] = None,
     ) -> BytecodeTableRow:
         query = {
             "bytecode_hash": bytecode_hash,
@@ -644,13 +644,13 @@ class Tables:
         rw_counter: Expression,
         rw: Expression,
         tag: Expression,
-        key1: Expression = None,
-        key2: Expression = None,
-        key3: Expression = None,
-        key4: Expression = None,
-        value: Expression = None,
-        value_prev: Expression = None,
-        aux0: Expression = None,
+        key1: Optional[Expression] = None,
+        key2: Optional[Expression] = None,
+        key3: Optional[Expression] = None,
+        key4: Optional[Expression] = None,
+        value: Optional[Expression] = None,
+        value_prev: Optional[Expression] = None,
+        aux0: Optional[Expression] = None,
     ) -> RWTableRow:
         query = {
             "rw_counter": rw_counter,
@@ -677,7 +677,7 @@ class Tables:
         dst_addr: Expression,
         length: Expression,
         rw_counter: Expression,
-        log_id: Expression = None,
+        log_id: Optional[Expression] = None,
     ) -> CopyTableRow:
         if dst_type == CopyDataTypeTag.TxLog:
             assert log_id is not None

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -137,7 +137,7 @@ class Transaction:
         gas: U64 = U64(21000),
         gas_price: U256 = U256(int(2e9)),
         caller_address: U160 = U160(0xCAFE),
-        callee_address: U160 = None,
+        callee_address: Optional[U160] = None,
         value: U256 = U256(0),
         call_data: bytes = bytes(),
     ) -> None:
@@ -354,8 +354,8 @@ class Account:
         address: U160 = U160(0),
         nonce: U256 = U256(0),
         balance: U256 = U256(0),
-        code: Bytecode = None,
-        storage: Storage = None,
+        code: Optional[Bytecode] = None,
+        storage: Optional[Storage] = None,
     ) -> None:
         self.address = address
         self.nonce = nonce
@@ -483,7 +483,7 @@ class RWDictionary:
         tx_id: IntOrFQ,
         refund: IntOrFQ,
         refund_prev: IntOrFQ,
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
             RWTableTag.TxRefund,
@@ -499,7 +499,7 @@ class RWDictionary:
         account_address: IntOrFQ,
         value: bool,
         value_prev: bool,
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
             RWTableTag.TxAccessListAccount,
@@ -517,7 +517,7 @@ class RWDictionary:
         storage_key: RLC,
         value: bool,
         value_prev: bool,
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
             RWTableTag.TxAccessListAccountStorage,
@@ -549,7 +549,7 @@ class RWDictionary:
         field_tag: AccountFieldTag,
         value: Union[int, FQ, RLC],
         value_prev: Union[int, FQ, RLC],
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
@@ -593,7 +593,7 @@ class RWDictionary:
         value_prev: RLC,
         tx_id: IntOrFQ,
         value_committed: RLC,
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         if isinstance(tx_id, int):
             tx_id = FQ(tx_id)
@@ -618,7 +618,7 @@ class RWDictionary:
         value: Expression = FQ(0),
         value_prev: Expression = FQ(0),
         aux0: Expression = FQ(0),
-        rw_counter_of_reversion: int = None,
+        rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         self._append(
             RW.Write,
@@ -659,7 +659,7 @@ class RWDictionary:
         value: Expression = FQ(0),
         value_prev: Expression = FQ(0),
         aux0: Expression = FQ(0),
-        rw_counter: int = None,
+        rw_counter: Optional[int] = None,
     ) -> RWDictionary:
         if rw_counter is None:
             rw_counter = self.rw_counter


### PR DESCRIPTION
As [an error report](https://github.com/privacy-scaling-explorations/zkevm-specs/actions/runs/3426588988/jobs/5708575463) from CI:
```
...: PEP 484 prohibits implicit Optional.
...: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
```
Follow the instruction of [no_implicit_optional](https://github.com/hauntsaninja/no_implicit_optional) to fix with script as:
```
pip install no_implicit_optional
no_implicit_optional src/
no_implicit_optional tests/
```