### PR TITLE
reinforce linear_combine

### DIFF
--- a/src/zkevm_specs/public_inputs.py
+++ b/src/zkevm_specs/public_inputs.py
@@ -6,7 +6,7 @@ from .util import (
     U64,
     U160,
     U256,
-    linear_combine,
+    linear_combine_bytes,
     PUBLIC_INPUTS_BLOCK_LEN as BLOCK_LEN,
     PUBLIC_INPUTS_EXTRA_LEN as EXTRA_LEN,
     PUBLIC_INPUTS_TX_LEN as TX_LEN,
@@ -495,7 +495,7 @@ def public_data2witness(
         len(raw_public_inputs)
         == BLOCK_LEN + 1 + EXTRA_LEN + 3 * (TX_LEN * MAX_TXS + 1) + MAX_CALLDATA_BYTES
     )
-    rpi_rlc = linear_combine(raw_public_inputs, rand_rpi, range_check=False)
+    rpi_rlc = linear_combine_bytes(raw_public_inputs, rand_rpi, range_check=False)
     # NOTE: End rlc calculation of raw_public_inputs.
 
     rpi_rlc_acc_col = [raw_public_inputs[-1]]

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -4,7 +4,7 @@ from math import log, ceil
 
 from zkevm_specs.evm.table import MPTProofType
 
-from .util import FQ, RLC, U160, U256, Expression, linear_combine
+from .util import FQ, RLC, U160, U256, Expression, linear_combine_bytes
 from .encoding import U8, is_circuit_code
 from .evm import (
     RW,
@@ -430,10 +430,12 @@ def check_state_row(row: Row, row_prev: Row, row_next: Row, tables: Tables, rand
     # 0.1. address is linear combination of 10 x 16bit limbs and also in range
     for limb in row.address_limbs():
         assert_in_range(limb, 0, 2**16 - 1)
-    assert row.address() == linear_combine(row.address_limbs(), FQ(2**16), range_check=False)
+    assert row.address() == linear_combine_bytes(
+        row.address_limbs(), FQ(2**16), range_check=False
+    )
 
     # 0.2. address is RLC encoded
-    assert row.storage_key() == linear_combine(row.storage_key_bytes(), randomness)
+    assert row.storage_key() == linear_combine_bytes(row.storage_key_bytes(), randomness)
 
     # 0.3. is_write is boolean
     assert row.is_write in [0, 1]

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -6,7 +6,7 @@ from .util import (
     U160,
     U256,
     U64,
-    linear_combine,
+    linear_combine_bytes,
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
 )
@@ -224,14 +224,16 @@ class SignVerifyChip:
         )
 
         # 2. Verify that the first 20 bytes of the pub_key_hash equal the address
-        addr_expr = linear_combine(list(reversed(self.pub_key_hash.le_bytes[-20:])), FQ(2**8))
+        addr_expr = linear_combine_bytes(
+            list(reversed(self.pub_key_hash.le_bytes[-20:])), FQ(2**8)
+        )
         assert (
             addr_expr == self.address
         ), f"{assert_msg}: {hex(addr_expr.n)} != {hex(self.address.n)}"
 
         # 3. Verify that the signed message in the ecdsa_chip with RLC encoding
         # corresponds to msg_hash_rlc
-        msg_hash_rlc_expr = is_not_padding * linear_combine(self.msg_hash_bytes, randomness)
+        msg_hash_rlc_expr = is_not_padding * linear_combine_bytes(self.msg_hash_bytes, randomness)
         assert (
             msg_hash_rlc_expr == self.msg_hash_rlc
         ), f"{assert_msg}: {hex(msg_hash_rlc_expr.n)} != {hex(self.msg_hash_rlc.n)}"

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -5,14 +5,14 @@ from py_ecc.utils import prime_field_inv
 from .param import MAX_N_BYTES
 
 
-def linear_combine(seq: Sequence[Union[int, FQ]], base: FQ, range_check: bool = True) -> FQ:
+def linear_combine_bytes(seq: Sequence[Union[int, FQ]], base: FQ, range_check: bool = True) -> FQ:
     """
     Aggregate a sequence of data into a single field element.
     To use it as a commitment, the base must be a secured random number.
     If the input represents a sequence of data, apply the function directly.
     If the input represents a number, it must be in little-endian order.
     >>> r = 10
-    >>> assert linear_combine([1, 2, 3], r) == 1 + 2 * r + 3 * r**2
+    >>> assert linear_combine_bytes([1, 2, 3], r) == 1 + 2 * r + 3 * r**2
     """
     result = FQ.zero()
     for limb in reversed(seq):
@@ -60,7 +60,7 @@ class RLC:
         value = value.ljust(n_bytes, b"\x00")
 
         self.int_value = int.from_bytes(value, "little")
-        self.rlc_value = linear_combine(value, randomness)
+        self.rlc_value = linear_combine_bytes(value, randomness)
         self.le_bytes = value
 
     def expr(self) -> FQ:


### PR DESCRIPTION
For an `n-ary` number, each digit should be in range `[0, n)`