### PR TITLE
Bug: fix to not invoke `transfer` for call related opcodes (except `CALL`)

### DIFF
--- a/specs/opcode/F1CALL_F2CALLCODE_F4DELEGATECALL_FASTATICCALL.md
+++ b/specs/opcode/F1CALL_F2CALLCODE_F4DELEGATECALL_FASTATICCALL.md
@@ -25,7 +25,8 @@ It creates a new sub context as setting caller address to parent caller's and ca
 - For opcode `STATICCALL`:
 It does not allow any state modifying instructions (is_static == 1) or sending ether to callee in the sub context.
 
-And both `DELEGATECALL` and `STATICCALL` opcodes only pop 6 words from stack `gas`, `callee_address`, `call_data_offset`, `call_data_length`, `return_data_offset` and `return_data_length` (except the third popped word `value` for both `CALL` and `CALLCODE` opcodes).
+Both `DELEGATECALL` and `STATICCALL` opcodes only pop 6 words from stack `gas`, `callee_address`, `call_data_offset`, `call_data_length`, `return_data_offset` and `return_data_length` (except the third popped word `value` for both `CALL` and `CALLCODE` opcodes).
+There should be no `transfer` invocation for `CALLCODE`, `DELEGATECALL`and `STATICCALL` (except `CALL`).
 
 Before switching call context to the new one, it does several things:
 
@@ -34,7 +35,7 @@ Before switching call context to the new one, it does several things:
 3. Calculate `gas_cost` and check `gas_left` is enough
 4. Calculate `callee_gas_left` for new context by rule in EIP150
 5. Check `depth` is less than `1024`
-6. Check `value` could be transfer (zero for both `DELEGATECALL` and `STATICCALL` opcodes)
+6. Check `value` could be transferred (only for `CALL` and `CALLCODE` opcodes)
 
 The memory size is calculated as follows:
 
@@ -84,7 +85,7 @@ callee_gas_left := min(gas_available - floor(gas_available / 64), gas)
 
 After switching call context, it does:
 
-1. Transfer `value` (zero for both `DELEGATECALL` and `STATICCALL` opcodes)
+1. Transfer `value` (only for `CALL` opcode)
 2. Execution
    1. If `callee_address` is a precompiled, it runs the pre-defined handler
    2. Otherwise, it takes callee's code for execution

--- a/specs/opcode/F1CALL_F2CALLCODE_F4DELEGATECALL_FASTATICCALL.md
+++ b/specs/opcode/F1CALL_F2CALLCODE_F4DELEGATECALL_FASTATICCALL.md
@@ -26,7 +26,7 @@ It creates a new sub context as setting caller address to parent caller's and ca
 It does not allow any state modifying instructions (is_static == 1) or sending ether to callee in the sub context.
 
 Both `DELEGATECALL` and `STATICCALL` opcodes only pop 6 words from stack `gas`, `callee_address`, `call_data_offset`, `call_data_length`, `return_data_offset` and `return_data_length` (except the third popped word `value` for both `CALL` and `CALLCODE` opcodes).
-There should be no `transfer` invocation for `CALLCODE`, `DELEGATECALL`and `STATICCALL` (except `CALL`).
+There should be no `transfer` invocation for `CALLCODE`, `DELEGATECALL`and `STATICCALL` (only for CALL).
 
 Before switching call context to the new one, it does several things:
 

--- a/src/zkevm_specs/evm/execution/callop.py
+++ b/src/zkevm_specs/evm/execution/callop.py
@@ -169,7 +169,7 @@ def callop(instruction: Instruction):
 
         # For CALL opcode, it has an extra stack pop `value` and two account write for `transfer` call (+3).
         # For CALLCODE opcode, it has an extra stack pop `value` and one account read for callee balance (+2).
-        # For DELEGATECALL opcode, has two extra call context lookups for current caller address and value (+2).
+        # For DELEGATECALL opcode, has two extra call context lookups for current caller address and value, and one account read for callee balance (+3).
         # For STATICCALL opcode, it has one account read for callee balance (+1).
         rw_counter_delta = 21 + is_call * 3 + is_callcode * 2 + is_delegatecall * 3 + is_staticcall
         stack_pointer_delta = 5 + is_call + is_callcode

--- a/src/zkevm_specs/evm/execution/callop.py
+++ b/src/zkevm_specs/evm/execution/callop.py
@@ -110,17 +110,18 @@ def callop(instruction: Instruction):
 
     if is_call == 1:
         # For CALL opcode, verify transfer, and get caller balance before
-        # transfer to constrain it should be greater or equal to stack `value`.
+        # transfer to constrain it should be greater than or equal to stack
+        # `value`.
         (_, caller_balance), _ = instruction.transfer(
             caller_address, callee_address, value, callee_reversion_info
         )
     elif is_callcode == 1:
         # For CALLCODE opcode, get caller balance to constrain it should be
-        # greater or equal to stack `value`.
+        # greater than or equal to stack `value`.
         caller_balance = instruction.account_read(caller_address, AccountFieldTag.Balance)
 
-    # For both CALL and CALLCODE opcodes, verify caller balance is greater or
-    # equal to stack `value`.
+    # For both CALL and CALLCODE opcodes, verify caller balance is greater than
+    # or equal to stack `value`.
     if is_call + is_callcode == 1:
         value_lt_caller_balance, value_eq_caller_balance = instruction.compare_word(
             value, caller_balance

--- a/tests/evm/test_callop.py
+++ b/tests/evm/test_callop.py
@@ -345,7 +345,7 @@ def test_callop(
             .account_write(caller.address, AccountFieldTag.Balance, caller_balance, caller_balance_prev, rw_counter_of_reversion=None if callee_is_persistent else callee_rw_counter_end_of_reversion) \
             .account_write(callee.address, AccountFieldTag.Balance, callee_balance, callee_balance_prev, rw_counter_of_reversion=None if callee_is_persistent else callee_rw_counter_end_of_reversion - 1)
     elif is_callcode == 1:
-        # Get caller balance to constrain it should be greater or equal to stack `value`.
+        # Get caller balance to constrain it should be greater than or equal to stack `value`.
         rw_dictionary \
             .account_read(caller.address, AccountFieldTag.Balance, RLC(caller.balance, randomness))
 

--- a/tests/evm/test_callop.py
+++ b/tests/evm/test_callop.py
@@ -269,7 +269,7 @@ def test_callop(
 
     # For CALL opcode, it has an extra stack pop `value` and two account write for `transfer` call (+3).
     # For CALLCODE opcode, it has an extra stack pop `value` and one account read for callee balance (+2).
-    # For DELEGATECALL opcode, has two extra call context lookups for current caller address and value (+2).
+    # For DELEGATECALL opcode, has two extra call context lookups for current caller address and value, and one account read for callee balance (+3).
     # For STATICCALL opcode, it has one account read for callee balance (+1).
     call_id = 21 + is_call * 3 + is_callcode * 2 + is_delegatecall * 3 + is_staticcall
     rw_counter = call_id


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-specs/issues/334

Related circuit PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/973

As issue described, there should be no `transfer` invocation for call related opcodes (except [CALL](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L167)) - [CALLCODE](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L253), [DELEGATECALL](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L301) and [STATICCALL](https://github.com/ethereum/go-ethereum/blob/master/core/vm/evm.go#L340).

~~And callee balance is also needed for checking account existence below (for now). Suppose if it could be fixed to replace with [non-existing proofs](https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/907) after using in the [BALANCE circuit](https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/683).~~

