### PR TITLE
State circuit "start" tag constraints fix

### DIFF
--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -83,7 +83,7 @@ class Row(NamedTuple):
 
     root: FQ
 
-    # lexicographic_ordering_selector is the selector for StartOp and this is set 0 if first Row otherwise 0
+    # lexicographic_ordering_selector is the selector for transition checks and this is set 0 if first Row otherwise 1
     lexicographic_ordering_selector: FQ
 
     # fmt: on

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -83,6 +83,9 @@ class Row(NamedTuple):
 
     root: FQ
 
+    # lexicographic_ordering_selector is the selector for StartOp and this is set 0 if first Row otherwise 0
+    lexicographic_ordering_selector: FQ
+
     # fmt: on
 
     def tag(self):
@@ -169,8 +172,26 @@ def assert_in_range(x: FQ, min_val: int, max_val: int) -> None:
 
 @is_circuit_code
 def check_start(row: Row, row_prev: Row):
-    # 1.0. rw_counter is 0
-    assert row.rw_counter == 0
+    # 1.0. field_tag is 0 for Start
+    assert row.field_tag() == 0
+
+    # 1.1. address is 0 for Start
+    assert row.address() == 0
+
+    # 1.2. id is 0 for Start
+    assert row.id() == 0
+
+    # 1.3. storage_key is 0 for Start
+    assert row.storage_key() == 0
+
+    # 1.4. rw_counter increases by 1 for every non-first row
+    assert row.lexicographic_ordering_selector * (row.rw_counter - row_prev.rw_counter - 1) == 0
+
+    # 1.5. Start value is 0
+    assert row.value == 0
+
+    # 1.6. state_root is unchanged for Start
+    assert row.lexicographic_ordering_selector * (row.root - row_prev.root) == 0
 
 
 @is_circuit_code
@@ -549,6 +570,7 @@ class Operation(NamedTuple):
     storage_key: U256
     value: FQ
     committed_value: FQ
+    lexicographic_ordering_selector: FQ
 
 
 class StartOp(Operation):
@@ -556,11 +578,12 @@ class StartOp(Operation):
     Start Operation
     """
 
-    def __new__(self):
+    def __new__(self, rw_counter: int, rw: RW, lexicographic_ordering_selector: int = 1):
         # fmt: off
-        return super().__new__(self, 0, 0,
+        return super().__new__(self, rw_counter, rw,
                 U256(Tag.Start), U256(0), U256(0), U256(0), U256(0), # keys
-                FQ(0), FQ(0)) # values
+                FQ(0), FQ(0), # values
+                FQ(lexicographic_ordering_selector)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -578,7 +601,8 @@ class MemoryOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.Memory), U256(call_id), U256(mem_addr), U256(0), U256(0), # keys
-                FQ(value), FQ(0)) # values
+                FQ(value), FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -591,7 +615,8 @@ class StackOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.Stack), U256(call_id), U256(stack_ptr), U256(0), U256(0), # keys
-                value, FQ(0)) # values
+                FQ(value), FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -613,7 +638,8 @@ class StorageOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.Storage), U256(tx_id), U256(addr), U256(0), U256(key), # keys
-                value, committed_value) # values
+                value, committed_value, # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -628,7 +654,8 @@ class CallContextOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.CallContext), U256(call_id), U256(0), U256(field_tag), U256(0), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -649,7 +676,8 @@ class AccountOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.Account), U256(0), U256(addr), U256(field_tag), U256(0), # keys
-                value, committed_value) # values
+                value, committed_value, # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -662,7 +690,8 @@ class TxRefundOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.TxRefund), U256(tx_id), U256(0), U256(0), U256(0), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -675,7 +704,8 @@ class TxAccessListAccountOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.TxAccessListAccount), U256(tx_id), U256(addr), U256(0), U256(0), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -689,7 +719,8 @@ class TxAccessListAccountStorageOp(Operation):
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.TxAccessListAccountStorage),
                 U256(tx_id), U256(addr), U256(0), U256(key), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -702,7 +733,8 @@ class AccountDestructedOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.AccountDestructed), U256(0), U256(addr), U256(0), U256(0), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -724,7 +756,8 @@ class TxLogOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.TxLog),U256(tx_id), U256(log_id), U256(field_tag), U256(index), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
@@ -737,15 +770,12 @@ class TxReceiptOp(Operation):
         # fmt: off
         return super().__new__(self, rw_counter, rw,
                 U256(Tag.TxReceipt), U256(tx_id),  U256(0), U256(field_tag), U256(0), # keys
-                value, FQ(0)) # values
+                value, FQ(0), # values
+                FQ(1)) # lexicographic_ordering_selector
         # fmt: on
 
 
-def op2row(
-    op: Operation,
-    randomness: FQ,
-    root: FQ,
-) -> Row:
+def op2row(op: Operation, randomness: FQ, root: FQ) -> Row:
     rw_counter = FQ(op.rw_counter)
     is_write = FQ(0) if op.rw == RW.Read else FQ(1)
     tag = FQ(op.tag)
@@ -764,6 +794,7 @@ def op2row(
 
     value = FQ(op.value)
     committed_value = FQ(op.committed_value)
+    lexicographic_ordering_selector = FQ(op.lexicographic_ordering_selector)
 
     return Row(
         rw_counter,
@@ -774,6 +805,7 @@ def op2row(
         value,
         committed_value,
         root,
+        lexicographic_ordering_selector,
     )
 
 
@@ -836,6 +868,8 @@ def _mock_mpt_updates(ops: List[Operation], randomness: FQ) -> Dict[Tuple[FQ, FQ
             proof_type = MPTProofType.from_account_field_tag(field_tag)
 
         new_root = root + 5
+        if isinstance(op, StartOp):
+            new_root = root
         mpt_map[mpt_key] = MPTTableRow(
             FQ(op.address),
             FQ(proof_type),

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -83,7 +83,7 @@ class Row(NamedTuple):
 
     root: FQ
 
-    # lexicographic_ordering_selector is the selector for transition checks and this is set 0 if first Row otherwise 1
+    # lexicographic_ordering_selector is the selector for transition checks and is set 0 for the first Row and 1 otherwise.
     lexicographic_ordering_selector: FQ
 
     # fmt: on

--- a/tests/test_state_circuit.py
+++ b/tests/test_state_circuit.py
@@ -41,9 +41,9 @@ def verify(
 def test_state_ok():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
-        StartOp(rw_counter=1, rw=RW.Read),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StartOp(rw_counter=2, rw=RW.Read),
+        StartOp(rw_counter=3, rw=RW.Read),
 
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
         MemoryOp(rw_counter=2, rw=RW.Write, call_id=1, mem_addr=0, value=42),
@@ -99,7 +99,7 @@ def test_state_ok():
 def test_mpt_updates_ok():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
 
         StorageOp(rw_counter=7, rw=RW.Read,  tx_id=1, addr=0x12345678, key=0x1516, value=rlc(789), committed_value=rlc(789)),
         StorageOp(rw_counter=8, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x4959, value=rlc(38491), committed_value=rlc(98765)),
@@ -115,7 +115,7 @@ def test_mpt_updates_ok():
 def test_state_bad_key2():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
     # fmt: on
@@ -129,7 +129,7 @@ def test_state_bad_key2():
 def test_state_bad_key4():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
     ]
     # fmt: on
@@ -143,7 +143,7 @@ def test_state_bad_key4():
 def test_state_bad_is_write():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
     ]
     # fmt: on
@@ -157,7 +157,7 @@ def test_state_bad_is_write():
 def test_state_keys_non_lexicographic_order():
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x1112, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x1111, value=rlc(789), committed_value=rlc(98765)),
     ]
@@ -167,7 +167,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=2 << 250, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=1 << 250, value=rlc(789), committed_value=rlc(98765)),
     ]
@@ -177,7 +177,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=123, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=123, value=rlc(789), committed_value=rlc(98765)),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
@@ -188,7 +188,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=0, value=0),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
     ]
@@ -201,7 +201,7 @@ def test_state_bad_rwc():
     # fmt: off
     # rwc decreases
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
@@ -214,7 +214,7 @@ def test_state_bad_read_consistency():
     # fmt: off
     # Read a 0 after writing a 8
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
         MemoryOp(rw_counter=2, rw=RW.Write, call_id=2, mem_addr=123, value=8),
         MemoryOp(rw_counter=3, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
@@ -229,7 +229,7 @@ def first_memory_op(rw_counter=1, rw=RW.Write, call_id=1, mem_addr=2**32 - 1, va
 
 
 def test_first_memory_op_ok():
-    ops = [StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0), first_memory_op()]
+    ops = [StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0), first_memory_op()]
     tables = Tables(mpt_table_from_ops(ops, randomness))
     verify(ops, tables, randomness, success=True)
 
@@ -237,7 +237,7 @@ def test_first_memory_op_ok():
 def test_memory_bad_address():
     # memory address too big
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         first_memory_op(mem_addr=2**32),
     ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
@@ -247,7 +247,7 @@ def test_memory_bad_address():
 def test_memory_bad_first_access():
     # first access is a read but value != 0
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         first_memory_op(rw=RW.Read),
     ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
@@ -257,7 +257,7 @@ def test_memory_bad_first_access():
 def test_memory_bad_value_range():
     # memory value too big
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         first_memory_op(value=2**8),
     ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
@@ -268,7 +268,7 @@ def test_stack_bad_first_access():
     # fmt: off
     # first stack operation is read
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Read, call_id=1, stack_ptr=1023, value=rlc(4321)),
     ]
     # fmt: on
@@ -280,7 +280,7 @@ def test_stack_bad_stack_ptr_range():
     # fmt: off
     # stack pointer is too big
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1024, value=rlc(4321)),
     ]
     # fmt: on
@@ -292,7 +292,7 @@ def test_stack_bad_stack_ptr_inc():
     # fmt: off
     # stack pointer increases by 2
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1021, value=rlc(4321)),
         StackOp(rw_counter=2, rw=RW.Write, call_id=1, stack_ptr=1023, value=rlc(4321)),
     ]
@@ -305,7 +305,7 @@ def test_tx_log_bad():
     # fmt: off
     # tx_id change must be increasing
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         TxLogOp(rw_counter=2, rw=RW.Write, tx_id=2, log_id=1, field_tag=TxLogFieldTag.Data, index=0, value=FQ(10)),
         TxLogOp(rw_counter=1, rw=RW.Write, tx_id=2, log_id=2, field_tag=TxLogFieldTag.Address, index=0, value=FQ(124)),
         TxLogOp(rw_counter=3, rw=RW.Write, tx_id=1, log_id=2, field_tag=TxLogFieldTag.Data, index=0, value=FQ(255)),
@@ -319,7 +319,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # PostStateOrStatus is invalid
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
     ]
     # fmt: on
@@ -329,7 +329,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # tx_id is decreasing when changes
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=2, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
         TxReceiptOp(rw_counter=2, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.CumulativeGasUsed, value=FQ(200)),
     ]
@@ -340,7 +340,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # tx_id is not increasing by one
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
         TxReceiptOp(rw_counter=2, rw=RW.Read, tx_id=5, field_tag=TxReceiptFieldTag.CumulativeGasUsed, value=FQ(200)),
     ]
@@ -353,7 +353,7 @@ def test_rw_counter_zero_bad():
     # fmt: off
     # rw_counter is 0 but tag is not Start
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=0, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
     # fmt: on
@@ -365,7 +365,7 @@ def test_storage_committed_value_bad():
     # fmt: off
     # Committed value changes but keys don't
     ops = [
-        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
         StorageOp(rw_counter=2, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(123), committed_value=rlc(123)),
     ]

--- a/tests/test_state_circuit.py
+++ b/tests/test_state_circuit.py
@@ -41,9 +41,9 @@ def verify(
 def test_state_ok():
     # fmt: off
     ops = [
-        StartOp(),
-        StartOp(),
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        StartOp(rw_counter=1, rw=RW.Read),
+        StartOp(rw_counter=2, rw=RW.Read),
 
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
         MemoryOp(rw_counter=2, rw=RW.Write, call_id=1, mem_addr=0, value=42),
@@ -99,7 +99,7 @@ def test_state_ok():
 def test_mpt_updates_ok():
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
 
         StorageOp(rw_counter=7, rw=RW.Read,  tx_id=1, addr=0x12345678, key=0x1516, value=rlc(789), committed_value=rlc(789)),
         StorageOp(rw_counter=8, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x4959, value=rlc(38491), committed_value=rlc(98765)),
@@ -115,7 +115,7 @@ def test_mpt_updates_ok():
 def test_state_bad_key2():
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
     # fmt: on
@@ -129,7 +129,7 @@ def test_state_bad_key2():
 def test_state_bad_key4():
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
     ]
     # fmt: on
@@ -143,7 +143,7 @@ def test_state_bad_key4():
 def test_state_bad_is_write():
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
     ]
     # fmt: on
@@ -157,7 +157,7 @@ def test_state_bad_is_write():
 def test_state_keys_non_lexicographic_order():
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x1112, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x1111, value=rlc(789), committed_value=rlc(98765)),
     ]
@@ -167,7 +167,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=2 << 250, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=1 << 250, value=rlc(789), committed_value=rlc(98765)),
     ]
@@ -177,7 +177,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=123, value=rlc(98765), committed_value=rlc(98765)),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=123, value=rlc(789), committed_value=rlc(98765)),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
@@ -188,7 +188,7 @@ def test_state_keys_non_lexicographic_order():
 
     # fmt: off
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=0, value=0),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
     ]
@@ -201,7 +201,7 @@ def test_state_bad_rwc():
     # fmt: off
     # rwc decreases
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=2, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
@@ -214,7 +214,7 @@ def test_state_bad_read_consistency():
     # fmt: off
     # Read a 0 after writing a 8
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
         MemoryOp(rw_counter=2, rw=RW.Write, call_id=2, mem_addr=123, value=8),
         MemoryOp(rw_counter=3, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
@@ -224,47 +224,42 @@ def test_state_bad_read_consistency():
     verify(ops, tables, randomness, success=False)
 
 
-def test_start_bad():
-    # fmt: off
-    ops = [
-        StartOp(),
-        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
-    ]
-    # fmt: on
-    rows = assign_state_circuit(ops, r)
-    # rw_counter is 1 on Tag.Start
-    rows[0] = rows[0]._replace(rw_counter=FQ(1))
-    tables = Tables(mpt_table_from_ops(ops, randomness))
-    verify(rows, tables, randomness, success=False)
-
-
 def first_memory_op(rw_counter=1, rw=RW.Write, call_id=1, mem_addr=2**32 - 1, value=3):
     return MemoryOp(rw_counter, rw, call_id, mem_addr, value)
 
 
 def test_first_memory_op_ok():
-    ops = [StartOp(), first_memory_op()]
+    ops = [StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0), first_memory_op()]
     tables = Tables(mpt_table_from_ops(ops, randomness))
     verify(ops, tables, randomness, success=True)
 
 
 def test_memory_bad_address():
     # memory address too big
-    ops = [StartOp(), first_memory_op(mem_addr=2**32)]
+    ops = [
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        first_memory_op(mem_addr=2**32),
+    ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
     verify(ops, tables, randomness, success=False)
 
 
 def test_memory_bad_first_access():
     # first access is a read but value != 0
-    ops = [StartOp(), first_memory_op(rw=RW.Read)]
+    ops = [
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        first_memory_op(rw=RW.Read),
+    ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
     verify(ops, tables, randomness, success=False)
 
 
 def test_memory_bad_value_range():
     # memory value too big
-    ops = [StartOp(), first_memory_op(value=2**8)]
+    ops = [
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
+        first_memory_op(value=2**8),
+    ]
     tables = Tables(mpt_table_from_ops(ops, randomness))
     verify(ops, tables, randomness, success=False)
 
@@ -273,7 +268,7 @@ def test_stack_bad_first_access():
     # fmt: off
     # first stack operation is read
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Read, call_id=1, stack_ptr=1023, value=rlc(4321)),
     ]
     # fmt: on
@@ -285,7 +280,7 @@ def test_stack_bad_stack_ptr_range():
     # fmt: off
     # stack pointer is too big
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1024, value=rlc(4321)),
     ]
     # fmt: on
@@ -297,7 +292,7 @@ def test_stack_bad_stack_ptr_inc():
     # fmt: off
     # stack pointer increases by 2
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1021, value=rlc(4321)),
         StackOp(rw_counter=2, rw=RW.Write, call_id=1, stack_ptr=1023, value=rlc(4321)),
     ]
@@ -310,7 +305,7 @@ def test_tx_log_bad():
     # fmt: off
     # tx_id change must be increasing
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         TxLogOp(rw_counter=2, rw=RW.Write, tx_id=2, log_id=1, field_tag=TxLogFieldTag.Data, index=0, value=FQ(10)),
         TxLogOp(rw_counter=1, rw=RW.Write, tx_id=2, log_id=2, field_tag=TxLogFieldTag.Address, index=0, value=FQ(124)),
         TxLogOp(rw_counter=3, rw=RW.Write, tx_id=1, log_id=2, field_tag=TxLogFieldTag.Data, index=0, value=FQ(255)),
@@ -324,7 +319,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # PostStateOrStatus is invalid
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
     ]
     # fmt: on
@@ -334,7 +329,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # tx_id is decreasing when changes
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=2, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
         TxReceiptOp(rw_counter=2, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.CumulativeGasUsed, value=FQ(200)),
     ]
@@ -345,7 +340,7 @@ def test_tx_receipt_bad():
     # fmt: off
     # tx_id is not increasing by one
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         TxReceiptOp(rw_counter=1, rw=RW.Read, tx_id=1, field_tag=TxReceiptFieldTag.PostStateOrStatus, value=FQ(3)),
         TxReceiptOp(rw_counter=2, rw=RW.Read, tx_id=5, field_tag=TxReceiptFieldTag.CumulativeGasUsed, value=FQ(200)),
     ]
@@ -358,7 +353,7 @@ def test_rw_counter_zero_bad():
     # fmt: off
     # rw_counter is 0 but tag is not Start
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         MemoryOp(rw_counter=0, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
     ]
     # fmt: on
@@ -370,7 +365,7 @@ def test_storage_committed_value_bad():
     # fmt: off
     # Committed value changes but keys don't
     ops = [
-        StartOp(),
+        StartOp(rw_counter=0, rw=RW.Read, lexicographic_ordering_selector=0),
         StorageOp(rw_counter=1, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(789), committed_value=rlc(789)),
         StorageOp(rw_counter=2, rw=RW.Write, tx_id=1, addr=0x12345678, key=0x15161718, value=rlc(123), committed_value=rlc(123)),
     ]


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-specs/issues/275

I did following things in this PR.

- Add `lexicographic_ordering_selector` flag to Row and Operation
- Fix [check_start](https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/src/zkevm_specs/state.py#L171) constraints

The circuit constraints and logics are aligned with zkevm-circuits.
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/state_circuit/constraint_builder.rs

I would appreciate it if you could confirm.
Thank you.