### PR TITLE
[WIP] Add non-existing check for SLOAD/SSTORE

### DIFF
--- a/specs/opcode/54SLOAD_55SSTORE.md
+++ b/specs/opcode/54SLOAD_55SSTORE.md
@@ -21,12 +21,12 @@
      - `SLOAD`: +8
        - 4 call_context read
        - 2 stack operations
-       - 1 storage reads
+       - 2 storage reads
        - 1 access_list write
      - `SSTORE`: +10
        - 5 call_context read
        - 2 stack operations
-       - 1 storage reads/writes
+       - 2 storage reads/writes
        - 1 access_list write
        - 1 gas_refund writes
    - stack_pointer
@@ -68,7 +68,7 @@
              - `original_value == 0`: gas_refund + SSTORE_SET_GAS - SLOAD_GAS
              - `original_value != 0`: gas_refund + SSTORE_RESET_GAS - SLOAD_GAS
 3. lookups:
-   - `SLOAD`: 8 busmapping lookups
+   - `SLOAD`: 9 busmapping lookups
      - call_context:
        - `tx_id`: Read the `tx_id` for this tx.
        - `rw_counter_end_of_reversion`: Read the `rw_counter_end` if this tx get reverted.
@@ -77,9 +77,11 @@
      - stack:
        - `key` is popped off the top of the stack
        - `value` is pushed on top of the stack
-     - storage: The 32 bytes of `value` are read from storage at `key`
+     - storage: 
+       - Check the existance of the storage associated to `callee_address`.
+       - The 32 bytes of `value` are read from storage at `key`
      - access_list: Write as `true` for `key`
-   - `SSTORE`: 10 busmapping lookups
+   - `SSTORE`: 11 busmapping lookups
      - call_context:
        - `tx_id`: Read the `tx_id` for this tx.
        - `is_static`: Read the call's property `is_static`
@@ -90,6 +92,7 @@
        - `key` is popped off the top of the stack
        - `value` is popped off the top of the stack
      - storage:
+       - Check the existance of the storage associated to `callee_address`.
        - The 32 bytes of new `value` are written to storage at `key`, with the previous `value` and `committed_value`
      - access_list: Write as `true` for `key`
      - gas_refund:

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -112,6 +112,10 @@ NOTE: `kN` means `keyN`
 | $counter | $isWrite    | Stack                      | $callID     | $stackPointer      |                            |                     | $value     | 0               | $root              |
 | $counter | $isWrite    | Memory                     | $callID     | $memoryAddress     |                            |                     | $value     | 0               | $root              |
 | $counter | $isWrite    | AccountStorage             | $txID       | $address           |                            | $storageKey         | $value     | $committedValue |
+|          |             |                            |             |                    |                            |                     |           |                  |       |
+|          |             |                            |             |                    | *AccountStorageTag*        |                     |           |                  |       |
+| $counter | false       | AccountStorage             |             | $address           | NonExisting                |                     | 0         | 0                | $root |
+|          |             |                            |             |                    |                            |                     |           |                  |                 |
 |          |             |                            |             |                    |                            |                     |            |            |                 |
 |          |             |                            |             |                    | *TxLogTag*                 |                     |            |            |                 |
 | $counter | true        | TxLog                      | $txID       | $logID,0           | Address                    | 0                   | $value     | 0               | $root              |

--- a/src/zkevm_specs/evm/execution/storage.py
+++ b/src/zkevm_specs/evm/execution/storage.py
@@ -51,7 +51,7 @@ def sload(instruction: Instruction):
 
     instruction.step_state_transition_in_same_context(
         opcode,
-        rw_counter=Transition.delta(9),
+        rw_counter=Transition.delta(8),
         program_counter=Transition.delta(1),
         stack_pointer=Transition.delta(0),
         reversible_write_counter=Transition.delta(1),

--- a/src/zkevm_specs/evm/execution/storage.py
+++ b/src/zkevm_specs/evm/execution/storage.py
@@ -92,7 +92,8 @@ def sstore(instruction: Instruction):
         else [RLC(0), RLC(0), RLC(0)]
     )
 
-    instruction.constrain_equal(storage_value, value)
+    if exists == 1:
+        instruction.constrain_equal(storage_value, value)
 
     is_warm = instruction.add_account_storage_to_access_list(
         tx_id,

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -22,6 +22,7 @@ from .opcode import Opcode
 from .step import StepState
 from .table import (
     AccountFieldTag,
+    AccountStorageTag,
     BlockContextFieldTag,
     BytecodeFieldTag,
     CallContextFieldTag,
@@ -922,6 +923,13 @@ class Instruction:
             reversion_info=reversion_info,
         )
         return cast_expr(row.value, RLC), cast_expr(row.value_prev, RLC), cast_expr(row.aux0, RLC)
+
+    def account_storage_field_read(self, account_address: Expression, account_storage_tag: AccountStorageTag) -> RLC:
+        return cast_expr(
+            self.rw_lookup(
+                RW.Read, RWTableTag.AccountStorage, key2=account_address, key3=FQ(account_storage_tag)
+            ).value, RLC,
+    )
 
     def add_account_to_access_list(
         self,

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -924,12 +924,18 @@ class Instruction:
         )
         return cast_expr(row.value, RLC), cast_expr(row.value_prev, RLC), cast_expr(row.aux0, RLC)
 
-    def account_storage_field_read(self, account_address: Expression, account_storage_tag: AccountStorageTag) -> RLC:
+    def account_storage_field_read(
+        self, account_address: Expression, account_storage_tag: AccountStorageTag
+    ) -> RLC:
         return cast_expr(
             self.rw_lookup(
-                RW.Read, RWTableTag.AccountStorage, key2=account_address, key3=FQ(account_storage_tag)
-            ).value, RLC,
-    )
+                RW.Read,
+                RWTableTag.AccountStorage,
+                key2=account_address,
+                key3=FQ(account_storage_tag),
+            ).value,
+            RLC,
+        )
 
     def add_account_to_access_list(
         self,

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -215,6 +215,7 @@ class AccountFieldTag(IntEnum):
     CodeHash = auto()
     NonExisting = auto()
 
+
 class AccountStorageTag(IntEnum):
     NonExisting = auto()
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -215,6 +215,9 @@ class AccountFieldTag(IntEnum):
     CodeHash = auto()
     NonExisting = auto()
 
+class AccountStorageTag(IntEnum):
+    NonExisting = auto()
+
 
 class CallContextFieldTag(IntEnum):
     """
@@ -341,6 +344,12 @@ class MPTProofType(IntEnum):
         elif field_tag == AccountFieldTag.NonExisting:
             return MPTProofType.NonExistingAccountProof
         raise Exception("Unexpected AccountFieldTag value")
+
+    @staticmethod
+    def from_account_storage_tag(storage_tag: AccountStorageTag) -> MPTProofType:
+        if storage_tag == AccountStorageTag.NonExisting:
+            return MPTProofType.NonExistingStorageProof
+        raise Exception("Unexpected AccountStorageTag value")
 
 
 class WrongQueryKey(Exception):

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -31,6 +31,7 @@ from ..util import (
 from .table import (
     RW,
     AccountFieldTag,
+    AccountStorageTag,
     BlockContextFieldTag,
     BlockTableRow,
     BytecodeFieldTag,
@@ -606,6 +607,23 @@ class RWDictionary:
             value_prev=value_prev,
             aux0=value_committed,
             rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def account_storage_field_read(
+        self,
+        account_address: IntOrFQ,
+        storage_field_tag: AccountStorageTag,
+        value: Union[int, FQ, RLC],
+    ) -> RWDictionary:
+        if isinstance(value, int):
+            value = FQ(value)
+        return self._append(
+            RW.Read,
+            RWTableTag.AccountStorage,
+            key2=FQ(account_address),
+            key3=FQ(storage_field_tag),
+            value=value,
+            value_prev=value,
         )
 
     def _state_write(

--- a/tests/evm/test_sload.py
+++ b/tests/evm/test_sload.py
@@ -71,8 +71,8 @@ def test_sload(
     bytecode = Bytecode().push32(storage_key_be_bytes).sload().stop()
     bytecode_hash = RLC(bytecode.hash(), randomness)
 
-    value = RLC(2, randomness) if exists else RLC(0, randomness) 
-    value_committed = RLC(0, randomness) if exists else RLC(0, randomness) 
+    value = RLC(2, randomness) if exists else RLC(0, randomness)
+    value_committed = RLC(0, randomness) if exists else RLC(0, randomness)
 
     rw_counter_end_of_reversion = 19
     reversible_write_counter = 3

--- a/tests/evm/test_sload.py
+++ b/tests/evm/test_sload.py
@@ -10,6 +10,7 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
     RWDictionary,
+    AccountStorageTag,
 )
 from zkevm_specs.util import rand_fq, rand_address, RLC, COLD_SLOAD_COST, WARM_STORAGE_READ_COST
 
@@ -17,32 +18,45 @@ TESTING_DATA = (
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address()),
         bytes([i for i in range(32, 0, -1)]),
+        1,
         False,
         True,
     ),
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address()),
         bytes([i for i in range(32, 0, -1)]),
+        0,  # Storage doesn't exist for this account
         True,
         True,
     ),
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address()),
         bytes([i for i in range(32, 0, -1)]),
+        1,
+        True,
+        True,
+    ),
+    (
+        Transaction(caller_address=rand_address(), callee_address=rand_address()),
+        bytes([i for i in range(32, 0, -1)]),
+        1,
         False,
         False,
     ),
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address()),
         bytes([i for i in range(32, 0, -1)]),
+        1,
         True,
         False,
     ),
 )
 
 
-@pytest.mark.parametrize("tx, storage_key_be_bytes, warm, is_persistent", TESTING_DATA)
-def test_sload(tx: Transaction, storage_key_be_bytes: bytes, warm: bool, is_persistent: bool):
+@pytest.mark.parametrize("tx, storage_key_be_bytes, exists, warm, is_persistent", TESTING_DATA)
+def test_sload(
+    tx: Transaction, storage_key_be_bytes: bytes, exists: int, warm: bool, is_persistent: bool
+):
     randomness = rand_fq()
 
     storage_key = RLC(bytes(reversed(storage_key_be_bytes)), randomness)
@@ -56,24 +70,44 @@ def test_sload(tx: Transaction, storage_key_be_bytes: bytes, warm: bool, is_pers
     rw_counter_end_of_reversion = 19
     reversible_write_counter = 3
 
+    rw_dictionary = (
+        RWDictionary(9)
+        .call_context_read(1, CallContextFieldTag.TxId, tx.id)
+        .call_context_read(
+            1,
+            CallContextFieldTag.RwCounterEndOfReversion,
+            0 if is_persistent else rw_counter_end_of_reversion,
+        )
+        .call_context_read(1, CallContextFieldTag.IsPersistent, is_persistent)
+        .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address)
+        .stack_read(1, 1023, storage_key)
+        .stack_write(1, 1023, value)
+        .tx_access_list_account_storage_write(
+            tx.id,
+            tx.callee_address,
+            storage_key,
+            1,
+            1 if warm else 0,
+            rw_counter_of_reversion=None
+            if is_persistent
+            else rw_counter_end_of_reversion - reversible_write_counter,
+        )
+    )
+
+    if exists == 1:
+        rw_dictionary.account_storage_read(
+            tx.callee_address, storage_key, value, tx.id, value_committed
+        )
+    else:
+        rw_dictionary.account_storage_field_read(
+            tx.callee_address, AccountStorageTag.NonExisting, RLC(exists, randomness)
+        )
+
     tables = Tables(
         block_table=set(Block().table_assignments(randomness)),
         tx_table=set(tx.table_assignments(randomness)),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            # fmt: off
-            RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.TxId, tx.id)
-            .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_persistent else rw_counter_end_of_reversion)
-            .call_context_read(1, CallContextFieldTag.IsPersistent, is_persistent)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address)
-            .stack_read(1, 1023, storage_key)
-            .account_storage_read(tx.callee_address, storage_key, value, tx.id, value_committed)
-            .stack_write(1, 1023, value)
-            .tx_access_list_account_storage_write(tx.id, tx.callee_address, storage_key, 1, 1 if warm else 0, rw_counter_of_reversion=None if is_persistent else rw_counter_end_of_reversion - reversible_write_counter)
-            .rws
-            # fmt: on
-        ),
+        rw_table=set(rw_dictionary.rws),
     )
 
     verify_steps(
@@ -91,10 +125,11 @@ def test_sload(tx: Transaction, storage_key_be_bytes: bytes, warm: bool, is_pers
                 stack_pointer=1023,
                 reversible_write_counter=reversible_write_counter,
                 gas_left=WARM_STORAGE_READ_COST if warm else COLD_SLOAD_COST,
+                aux_data=exists,
             ),
             StepState(
                 execution_state=ExecutionState.STOP if is_persistent else ExecutionState.REVERT,
-                rw_counter=17,
+                rw_counter=14,
                 call_id=1,
                 is_root=True,
                 is_create=False,

--- a/tests/evm/test_sstore.py
+++ b/tests/evm/test_sstore.py
@@ -73,7 +73,7 @@ def gen_test_cases():
                             value_case[1],  # if exists == 1 else bytes([0]),  # value_prev_diff
                             value_case[2],  # if exists == 1 else bytes([0]),  # original_value_diff
                             warm_case,  # is_warm_storage_key
-                            persist_case if exists else False,  # is_not_reverted
+                            persist_case,  # is_not_reverted
                         )
                     )
     return test_cases
@@ -162,17 +162,15 @@ def test_sstore(
             tx.callee_address, AccountStorageTag.NonExisting, RLC(1 - exists, randomness)
         )
 
-    (
-        rw_dictionary.tx_access_list_account_storage_write(
-            tx.id,
-            tx.callee_address,
-            RLC(storage_key, randomness),
-            1,
-            1 if warm else 0,
-            rw_counter_of_reversion=None if is_success else 13,
-        ).tx_refund_write(
-            tx.id, gas_refund, gas_refund_prev, rw_counter_of_reversion=None if is_success else 12
-        )
+    rw_dictionary.tx_access_list_account_storage_write(
+        tx.id,
+        tx.callee_address,
+        RLC(storage_key, randomness),
+        1,
+        1 if warm else 0,
+        rw_counter_of_reversion=None if is_success else 13,
+    ).tx_refund_write(
+        tx.id, gas_refund, gas_refund_prev, rw_counter_of_reversion=None if is_success else 12
     )
 
     tables = Tables(


### PR DESCRIPTION
In order to make account_storage reads/writes we need first to assert
that the storage for a particular account exists. Not only the account
but also the storage associated to it.

This adds into the table specs and implementation a new tag for
`AccountStorage` called `AccountStorageTag`. This allows to lookup the
existance of an account storage.

It also ports `SLOAD` and `SSTORE` to make usage of the lookups of existance.

Finally, updates the tests of these opcodes adding any required methods for them.