### PR TITLE
Specify constraints for TxRefund in State circuit

### DIFF
--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -334,8 +334,10 @@ def check_tx_refund(row: Row, row_prev: Row):
     # 7.1 state root does not change
     assert row.root == row_prev.root
 
-    # TODO: Missing constraints
-    # - When keys change, value must be 0
+    # 7.2 First access for a set of all keys
+    # - If READ, value must be 0
+    if not all_keys_eq(row, row_prev) and row.is_write == 0:
+        assert row.value == 0
 
 
 @is_circuit_code


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-specs/issues/244

I added following constraint.
https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/e74c5e7680bd5e4cb089aeb1d6a389e050a8169c/zkevm-circuits/src/state_circuit/constraint_builder.rs#L319

I would appreciate it if you could confirm.
Thank you.