### PR TITLE
bug: add shf0 == shift.cells[0] constraint to shlshr

### DIFF
--- a/src/zkevm_specs/evm/execution/shl_shr.py
+++ b/src/zkevm_specs/evm/execution/shl_shr.py
@@ -68,6 +68,7 @@ def check_witness(
     instruction.constrain_equal(
         push.expr(), (is_shl * dividend.expr() + is_shr * quotient.expr()) * (1 - divisor_is_zero)
     )
+    instruction.constrain_zero(shf0 - FQ(shift.le_bytes[0]))
 
     # Constrain shift == shift.cells[0] when divisor != 0.
     instruction.constrain_zero(


### PR DESCRIPTION
The fix to the issue https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1124 has been implemented in the circuit in https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1125/.

This PR syncs the fix to the spec.

