### PR TITLE
Markdown doc for `ErrorOutOfGasSloadSstore` state

### DIFF
--- a/specs/error_state/ErrorOutOfGasSloadSstore.md
+++ b/specs/error_state/ErrorOutOfGasSloadSstore.md
@@ -25,7 +25,7 @@ For this gadget, SSTORE gas cost is calculated with EIP-3529 as:
 if value == value_prev:
   gas_cost = SLOAD_GAS # 100
 else:
-  if value == original_value:
+  if value_prev == original_value:
     if original_value == 0:
       gas_cost = SSTORE_SET_GAS # 20000
     else:

--- a/specs/error_state/ErrorOutOfGasSloadSstore.md
+++ b/specs/error_state/ErrorOutOfGasSloadSstore.md
@@ -1,0 +1,62 @@
+# ErrorOutOfGasSloadSstore state for both SLOAD and SSTORE OOG errors
+
+## Procedure
+
+Handle the corresponding out of gas errors for both `SLOAD` and `SSTORE` opcodes.
+
+### EVM behavior
+
+For the current `go-ethereum` code, the out of gas error may occur for `constant gas` or `dynamic gas`.
+
+#### SLOAD gas cost
+
+For this gadget, SLOAD gas cost is calculated with EIP-2929 as:
+```
+if is_warm_access:
+  gas_cost = GAS_COST_WARM_ACCESS # 100
+else:
+  gas_cost = COLD_SLOAD_COST # 2100
+```
+
+#### SSTORE gas cost
+
+For this gadget, SSTORE gas cost is calculated with EIP-3529 as:
+```
+if value == value_prev:
+  gas_cost = SLOAD_GAS # 100
+else:
+  if value == original_value:
+    if original_value == 0:
+      gas_cost = SSTORE_SET_GAS # 20000
+    else:
+      gas_cost = SSTORE_RESET_GAS # 2900
+  else:
+    gas_cost = SLOAD_GAS # 100
+
+if not is_warm_access:
+  gas_cost += COLD_SLOAD_COST # 2100
+```
+
+#### SSTORE reentrancy sentry
+
+For SSTORE, the OOG error occurs when the gas left is less than or equal to `SSTORE_SENTRY` (2300).
+
+### Constraints
+
+1. For SLOAD, constrain `gas_left < gas_cost`.
+2. For SSTORE, constrain `gas_left < gas_cost` or `gas_left <= SSTORE_SENTRY`.
+3. Only for SSTORE, constrain `is_static == false`.
+4. Current call must fail.
+5. If it's a root call, it transits to `EndTx`.
+6. If it isn't a root call, it restores caller's context by reading to `rw_table`, then does step state transition to it.
+7. Constrain `rw_counter_end_of_reversion = rw_counter_end_of_step + reversible_counter`.
+
+### Lookups
+
+7 bus-mapping lookups for SLOAD and 9 for SSTORE:
+
+1. 5 call context lookups for `tx_id`, `is_static`, `callee_address`, `is_success` and `rw_counter_end_of_reversion`.
+2. 1 stack read for `storage_key`.
+3. 1 account storage access list read.
+4. Only for SSTORE, 1 stack read for `value_to_store`.
+5. Only for SSTORE, 1 account storage read.

--- a/src/zkevm_specs/evm/execution_state.py
+++ b/src/zkevm_specs/evm/execution_state.py
@@ -116,8 +116,7 @@ class ExecutionState(IntEnum):
     ErrorOutOfGasEXP = auto()
     ErrorOutOfGasSHA3 = auto()
     ErrorOutOfGasEXTCODECOPY = auto()
-    ErrorOutOfGasSLOAD = auto()
-    ErrorOutOfGasSSTORE = auto()
+    ErrorOutOfGasSloadSstore = auto()
     # For CALL, CALLCODE, DELEGATECALL and STATICCALL opcodes which may run out of gas.
     ErrorOutOfGasCall = auto()
     ErrorOutOfGasCREATE2 = auto()
@@ -389,8 +388,7 @@ class ExecutionState(IntEnum):
             ExecutionState.ErrorOutOfGasEXP,
             ExecutionState.ErrorOutOfGasSHA3,
             ExecutionState.ErrorOutOfGasEXTCODECOPY,
-            ExecutionState.ErrorOutOfGasSLOAD,
-            ExecutionState.ErrorOutOfGasSSTORE,
+            ExecutionState.ErrorOutOfGasSloadSstore,
             ExecutionState.ErrorOutOfGasCall,
             ExecutionState.ErrorOutOfGasCREATE2,
             ExecutionState.ErrorOutOfGasSELFDESTRUCT,


### PR DESCRIPTION
Close https://github.com/privacy-scaling-explorations/zkevm-specs/issues/382

Circuit impl PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1147

For `SLOAD` gas calculation with EIP-2929 could reference [this go-ethereum function](https://github.com/ethereum/go-ethereum/blob/fd4230f695247102c249d5ece2c7f6760350ae6f/core/vm/operations_acl.go#L103
).
And for `SSTORE` gas calculation with EIP-3529 could reference [this go-ethereum function](https://github.com/ethereum/go-ethereum/blob/fd4230f695247102c249d5ece2c7f6760350ae6f/core/vm/operations_acl.go#L27).