### PR TITLE
Simplify `ErrorStack`

### DIFF
--- a/specs/error_state/ErrorStackOverflow_Underflow.md
+++ b/specs/error_state/ErrorStackOverflow_Underflow.md
@@ -10,16 +10,10 @@ when any one type error occurs:
 1. If it's a root call, it ends the execution.
 2. Otherwise, it restores caller's context and switch to it.
 
-### Circuit behavior 
-1. in order to get each step(op code)'s `min_stack_pointer` & `max_stack_pointer` value, construct new fixed tag
-called `opcode_stack` which holds the data.
-2. look up `opcode_stack` to retrieve current executing step's stack info(`minStack` & `maxStack`) 
-3. combine stack overflow & underflow circuit into one, need to check `is_stack_overflow` and `is_stack_underflow`
-is bool and only one is true at the mean while
-4. common error handling:
-  - the call's `IsSuccess` must be false 
-  - If it's a root call, it transits to `EndTx`.
-  - if it is not root call, it restores caller's context by reading to `rw_table`, then does step state transition to it.
+### Circuit behavior
+
+1. Do a bytecode lookup to get `opcode`.
+2. Do a fixed lookup for `FixedTableTag.ResponsibleOpcode` with `opcode` and auxiliary `stack_pointer` to make sure it's indeed in pre-built pairs of `ErrorStack`.
 
 ## Code
 

--- a/src/zkevm_specs/evm/execution/error_stack.py
+++ b/src/zkevm_specs/evm/execution/error_stack.py
@@ -1,31 +1,9 @@
-from ...util import FQ
-from ..instruction import Instruction, FixedTableTag
-from ..opcode import Opcode
-from ...util import N_BYTES_STACK
+from ..instruction import Instruction
 
 
 def stack_error(instruction: Instruction):
     # retrieve op code associated to stack error
     opcode = instruction.opcode_lookup(True)
-    # lookup min or max stack pointer
-    max_stack_pointer = FQ(Opcode(opcode.expr().n).max_stack_pointer())
-    min_sp = Opcode(opcode.expr().n).min_stack_pointer()
-    min_stack_pointer = FQ(min_sp if min_sp > 0 else 0)
-    instruction.fixed_lookup(
-        FixedTableTag.OpcodeStack, opcode, min_stack_pointer, max_stack_pointer
-    )
-
-    # check stack pointer is underflow or overflow
-    is_overflow, _ = instruction.compare(
-        instruction.curr.stack_pointer, FQ(min_stack_pointer), N_BYTES_STACK
-    )
-    is_underflow, _ = instruction.compare(
-        FQ(max_stack_pointer), instruction.curr.stack_pointer, N_BYTES_STACK
-    )
-    instruction.constrain_bool(is_underflow)
-    instruction.constrain_bool(is_overflow)
-
-    # constrain one of [is_underflow, is_overflow] must be true when stack error happens
-    instruction.constrain_equal(is_underflow + is_overflow, FQ(1))
+    instruction.responsible_opcode_lookup(opcode, instruction.curr.stack_pointer)
 
     instruction.constrain_error_state(1 + instruction.curr.reversible_write_counter.n)

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -701,8 +701,10 @@ class Instruction:
     def tx_gas_price(self, tx_id: Expression) -> RLC:
         return cast_expr(self.tx_context_lookup(tx_id, TxContextFieldTag.GasPrice), RLC)
 
-    def responsible_opcode_lookup(self, opcode: Expression):
-        self.fixed_lookup(FixedTableTag.ResponsibleOpcode, FQ(self.curr.execution_state), opcode)
+    def responsible_opcode_lookup(self, opcode: Expression, aux: Expression = FQ(0)):
+        self.fixed_lookup(
+            FixedTableTag.ResponsibleOpcode, FQ(self.curr.execution_state), opcode, aux
+        )
 
     def opcode_lookup(self, is_code: bool) -> FQ:
         index = self.curr.program_counter + self.program_counter_offset

--- a/src/zkevm_specs/evm/opcode.py
+++ b/src/zkevm_specs/evm/opcode.py
@@ -377,13 +377,6 @@ def stack_underflow_pairs() -> List[Tuple[Opcode, int]]:
     return pairs
 
 
-def stack_bounds() -> List[Tuple[Opcode, int, int]]:
-    pairs = []
-    for opcode in valid_opcodes():
-        pairs.append((opcode, opcode.min_stack_pointer(), opcode.max_stack_pointer()))
-    return pairs
-
-
 def constant_gas_cost_pairs() -> List[Tuple[Opcode, int]]:
     pairs = []
     for opcode in valid_opcodes():

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -9,7 +9,6 @@ from .precompile import precompile_info_pairs
 
 from ..util import Expression, FQ, RLC, word_to_lo_hi, word_to_64s
 from .execution_state import ExecutionState
-from .opcode import stack_bounds
 
 
 class FixedTableTag(IntEnum):
@@ -32,7 +31,6 @@ class FixedTableTag(IntEnum):
     ResponsibleOpcode = auto()  # execution_state, opcode, aux
     Pow2 = auto()  # value, value_pow
     OpcodeConstantGas = auto()  # opcode constant gas
-    OpcodeStack = auto()  # opcode stack info for stack error purpose
     PrecompileInfo = auto()  # precompile constant gas
 
     def table_assignments(self) -> List[FixedTableRow]:
@@ -80,12 +78,6 @@ class FixedTableTag(IntEnum):
             return [
                 FixedTableRow(FQ(self), FQ(code[0]), FQ(code[1]), FQ(0))
                 for code in constant_gas_cost_pairs()
-            ]
-        elif self == FixedTableTag.OpcodeStack:
-            return [
-                # flag | op code |  min stack | max stack
-                FixedTableRow(FQ(self), FQ(pair[0]), FQ(pair[1] if pair[1] > 0 else 0), FQ(pair[2]))
-                for pair in stack_bounds()
             ]
         elif self == FixedTableTag.Pow2:
             return [


### PR DESCRIPTION
This PR aims to simplify `ErrorStack` by using lookup to `FixedTable`. While reviewing other PRs I found out that the `ErrorStack` is not using `ResponsibleOpcode`, which already contains invalid stack pairs `(opcode, stack_pointer)` for quick lookup.

https://github.com/privacy-scaling-explorations/zkevm-specs/blob/f569eef524f4a19814b4a36cb081c9a9718a54dc/src/zkevm_specs/evm/execution_state.py#L354-L355

The circuit will need to be updated to have the `stack_{under,over}flow_pairs` for this simplification.