### PR TITLE
fix latest typing error

### DIFF
--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -360,6 +360,7 @@ class LookupAmbiguousFailure(Exception):
         self.message = f"Lookup {table_name} is ambiguous on inputs {inputs}, ${len(matched_rows)} matched rows found: {matched_rows}"
 
 
+@dataclass(frozen=True)
 class TableRow:
     @classmethod
     def validate_query(cls, table_name: str, query: Mapping[str, Any]):
@@ -431,7 +432,7 @@ class MPTTableRow(TableRow):
     value_prev: Expression
 
 
-@dataclass
+@dataclass(frozen=True)
 class CopyCircuitRow(TableRow):
     q_step: FQ
     is_first: FQ
@@ -477,7 +478,7 @@ class KeccakTableRow(TableRow):
     output: FQ
 
 
-@dataclass
+@dataclass(frozen=True)
 class ExpCircuitRow(TableRow):
     q_usable: FQ
     # columns from the exponentiation table

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import dataclasses
 from typing import (
     cast,
     Dict,
@@ -992,9 +993,9 @@ class CopyCircuit:
         # update the rwc_inc_left column
         rw_counter = rw_dict.rw_counter
         for row in new_rows:
-            row.rwc_inc_left = rw_counter - row.rw_counter
+            dataclasses.replace(row, rwc_inc_left=rw_counter - row.rw_counter)
             if dst_type == CopyDataTypeTag.RlcAcc:
-                row.rlc_acc = rlc_acc
+                dataclasses.replace(row, rlc_acc=rlc_acc)
         self.rows.extend(new_rows)
         return self
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -992,10 +992,12 @@ class CopyCircuit:
 
         # update the rwc_inc_left column
         rw_counter = rw_dict.rw_counter
-        for row in new_rows:
-            dataclasses.replace(row, rwc_inc_left=rw_counter - row.rw_counter)
-            if dst_type == CopyDataTypeTag.RlcAcc:
-                dataclasses.replace(row, rlc_acc=rlc_acc)
+        new_rows = [
+            dataclasses.replace(row, rwc_inc_left=rw_counter - row.rw_counter, rlc_acc=rlc_acc)
+            if dst_type == CopyDataTypeTag.RlcAcc
+            else dataclasses.replace(row, rwc_inc_left=rw_counter - row.rw_counter)
+            for row in new_rows
+        ]
         self.rows.extend(new_rows)
         return self
 


### PR DESCRIPTION
# Abstract
The CI failed because of mypy version upgrade.
https://github.com/privacy-scaling-explorations/zkevm-specs/actions/runs/4350682083/jobs/7601683721

## Reproduce
```
$ pip3 install mypy --upgrade
```
```shell
Collecting mypy>=0.931
  Downloading mypy-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.1 MB)
```

## Problem
`fields` function argument should be DataclassInstance.
https://github.com/privacy-scaling-explorations/zkevm-specs/blob/master/src/zkevm_specs/evm/table.py#L366

## Solution
Adding `@dataclass(frozen=True)` to `TableRow`, `CopyCircuitRow` and `ExpCircuitRow`.
Modifying frozen dataclass state with `dataclasses.replace`.

I would be happy if you could confirm or suggest better solution.