### PR TITLE
Implement Exp Circuit padding strategy

### DIFF
--- a/src/zkevm_specs/exp_circuit.py
+++ b/src/zkevm_specs/exp_circuit.py
@@ -28,9 +28,6 @@ def verify_step(cs: ConstraintSystem, rows: List[ExpCircuitRow]):
         cs.constrain_bool(rows[0].is_last)
         # remainder (r), i.e. odd/even parity of exponent is boolean.
         cs.constrain_bool(rows[0].r)
-        # is_last == 1 is followed by unusable row.
-        # is_last == 0 is following by usable row.
-        cs.constrain_equal(rows[0].is_last, (1 - rows[1].q_usable))
         # multiplication is assigned correctly
         _overflow, carry_lo_hi, additional_constraints = mul_add_words(
             rows[0].a, rows[0].b, rows[0].c, rows[0].d

--- a/tests/evm/test_exp.py
+++ b/tests/evm/test_exp.py
@@ -62,7 +62,11 @@ def test_exp(base_int: int, exponent_int: int):
         .stack_write(CALL_ID, 1023, exponentiation)
     )
 
-    exp_circuit = ExpCircuit().add_event(base.int_value(), exponent.int_value(), rw_dict.rw_counter)
+    exp_circuit = (
+        ExpCircuit()
+        .add_event(base.int_value(), exponent.int_value(), rw_dict.rw_counter)
+        .fill_dummy_events()
+    )
 
     tables = Tables(
         block_table=set(Block().table_assignments()),


### PR DESCRIPTION
This is https://github.com/privacy-scaling-explorations/zkevm-specs/pull/359 updated to resolve conflicts.

Implements the padding strategy for the Exp Circuit that doesn't require new constraints by adding dummy valid single-step exponentiation to fill the circuit.