### PR TITLE
Split Address when stored in Word 

### DIFF
--- a/specs/tables.md
+++ b/specs/tables.md
@@ -19,8 +19,8 @@ Proved by the tx circuit.
 | $TxID    | Nonce               | 0          | $value,0       |
 | $TxID    | Gas                 | 0          | $value,0       |
 | $TxID    | GasPrice            | 0          | $value{Lo,Hi}  |
-| $TxID    | CallerAddress       | 0          | $value,0       |
-| $TxID    | CalleeAddress       | 0          | $value,0       |
+| $TxID    | CallerAddress       | 0          | $value{Lo,Hi}  |
+| $TxID    | CalleeAddress       | 0          | $value{Lo,Hi}  |
 | $TxID    | IsCreate            | 0          | $value,0       |
 | $TxID    | Value               | 0          | $value{Lo,Hi}  |
 | $TxID    | CallDataLength      | 0          | $value,0       |
@@ -97,8 +97,8 @@ DELETEME: Review note: Removed aux1 and aux2 and instead added InitialValue whic
 | $counter | false       | CallContext                | $callID   |                    | CallerId                   |                           | $val,0           |                       |                        |
 | $counter | false       | CallContext                | $callID   |                    | TxId                       |                           | $val,0           |                       |                        |
 | $counter | false       | CallContext                | $callID   |                    | Depth                      |                           | $val,0           |                       |                        |
-| $counter | false       | CallContext                | $callID   |                    | CallerAddress              |                           | $val,0           |                       |                        |
-| $counter | false       | CallContext                | $callID   |                    | CalleeAddress              |                           | $val,0           |                       |                        |
+| $counter | false       | CallContext                | $callID   |                    | CallerAddress              |                           | $val{Lo,Hi}      |                       |                        |
+| $counter | false       | CallContext                | $callID   |                    | CalleeAddress              |                           | $val{Lo,Hi}      |                       |                        |
 | $counter | false       | CallContext                | $callID   |                    | CallDataOffset             |                           | $val,0           |                       |                        |
 | $counter | false       | CallContext                | $callID   |                    | CallDataLength             |                           | $val,0           |                       |                        |
 | $counter | false       | CallContext                | $callID   |                    | ReturnDataOffset           |                           | $val,0           |                       |                        |
@@ -128,7 +128,7 @@ DELETEME: Review note: Removed aux1 and aux2 and instead added InitialValue whic
 | $counter | $isWrite    | AccountStorage             | $txID     | $address           |                            | $storageKey{Lo,Hi}        | $val{Lo,Hi}      | $valPrev{Lo,Hi}       | $committedValue{Lo,Hi} |
 |          |             |                            |           |                    |                            |                           |                  |                       |                        |
 |          |             |                            |           |                    | *TxLogTag*                 |                           |                  |                       |                        |
-| $counter | true        | TxLog                      | $txID     | $logID,0           | Address                    |                           | $val,0           |                       |                        |
+| $counter | true        | TxLog                      | $txID     | $logID,0           | Address                    |                           | $val{Lo,Hi}      |                       |                        |
 | $counter | true        | TxLog                      | $txID     | $logID,$topicIndex | Topic                      |                           | $val{Lo,Hi}      |                       |                        |
 | $counter | true        | TxLog                      | $txID     | $logID,$byteIndex  | Data                       |                           | $val,0           |                       |                        |
 | $counter | true        | TxLog                      | $txID     | $logID,0           | TopicLength                |                           | $val,0           |                       |                        |

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -170,7 +170,7 @@ __Hence the addition inside of the block_table.__
 | 0 *Tag*                | 1 *Index* | 2 *Value{Lo,Hi}* |
 | ---                    | ---       | ---              |
 | *BlockContextFieldTag* |           |                  |
-| Coinbase               | 0         | $value,0         |
+| Coinbase               | 0         | $value{Lo,Hi}    |
 | GasLimit               | 0         | $value,0         |
 | BlockNumber            | 0         | $value,0         |
 | Time                   | 0         | $value,0         |

--- a/src/zkevm_specs/evm_circuit/execution/address.py
+++ b/src/zkevm_specs/evm_circuit/execution/address.py
@@ -7,10 +7,10 @@ def address(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.ADDRESS)
 
-    address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
     # Get callee address from call context and compare with stack top after push.
     instruction.constrain_equal_word(
-        instruction.address_to_word(address),
+        address_word,
         instruction.stack_push(),
     )
 

--- a/src/zkevm_specs/evm_circuit/execution/begin_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/begin_tx.py
@@ -25,9 +25,13 @@ def begin_tx(instruction: Instruction):
     if instruction.is_first_step:
         instruction.constrain_equal(tx_id, FQ(1))
 
-    tx_caller_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CallerAddress)
+    tx_caller_address_word = instruction.tx_context_lookup_word(
+        tx_id, TxContextFieldTag.CallerAddress
+    )
     tx_caller_address = instruction.word_to_address(tx_caller_address_word)
-    tx_callee_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CalleeAddress)
+    tx_callee_address_word = instruction.tx_context_lookup_word(
+        tx_id, TxContextFieldTag.CalleeAddress
+    )
     tx_callee_address = instruction.word_to_address(tx_callee_address_word)
     tx_is_create = instruction.tx_context_lookup(tx_id, TxContextFieldTag.IsCreate)
     tx_value = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.Value)

--- a/src/zkevm_specs/evm_circuit/execution/begin_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/begin_tx.py
@@ -25,8 +25,10 @@ def begin_tx(instruction: Instruction):
     if instruction.is_first_step:
         instruction.constrain_equal(tx_id, FQ(1))
 
-    tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
-    tx_callee_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CalleeAddress)
+    tx_caller_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CallerAddress)
+    tx_caller_address = instruction.word_to_address(tx_caller_address_word)
+    tx_callee_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CalleeAddress)
+    tx_callee_address = instruction.word_to_address(tx_callee_address_word)
     tx_is_create = instruction.tx_context_lookup(tx_id, TxContextFieldTag.IsCreate)
     tx_value = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.Value)
     tx_call_data_length = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataLength)
@@ -120,8 +122,8 @@ def begin_tx(instruction: Instruction):
             # - IsSuccess, IsPersistent will be verified in the end of tx
             for tag, word_or_value in [
                 (CallContextFieldTag.Depth, FQ(1)),
-                (CallContextFieldTag.CallerAddress, tx_caller_address),
-                (CallContextFieldTag.CalleeAddress, tx_callee_address),
+                (CallContextFieldTag.CallerAddress, tx_caller_address_word),
+                (CallContextFieldTag.CalleeAddress, tx_callee_address_word),
                 (CallContextFieldTag.CallDataOffset, FQ(0)),
                 (CallContextFieldTag.CallDataLength, tx_call_data_length),
                 (CallContextFieldTag.Value, tx_value),

--- a/src/zkevm_specs/evm_circuit/execution/block_ctx.py
+++ b/src/zkevm_specs/evm_circuit/execution/block_ctx.py
@@ -1,4 +1,3 @@
-from ...util import Word
 from ..instruction import Instruction, Transition
 from ..table import BlockContextFieldTag
 from ..opcode import Opcode
@@ -10,25 +9,19 @@ def blockctx(instruction: Instruction):
     # get block context op element
     if opcode == Opcode.COINBASE:
         op = BlockContextFieldTag.Coinbase
-        ctx_word = instruction.address_to_word(instruction.block_context_lookup(op))
     elif opcode == Opcode.TIMESTAMP:
         op = BlockContextFieldTag.Timestamp
-        ctx_word = Word.from_lo(instruction.block_context_lookup(op))
     elif opcode == Opcode.NUMBER:
         op = BlockContextFieldTag.Number
-        ctx_word = Word.from_lo(instruction.block_context_lookup(op))
     elif opcode == Opcode.GASLIMIT:
         op = BlockContextFieldTag.GasLimit
-        ctx_word = Word.from_lo(instruction.block_context_lookup(op))
     elif opcode == Opcode.DIFFICULTY:
         op = BlockContextFieldTag.Difficulty
-        ctx_word = instruction.block_context_lookup_word(op)
     elif opcode == Opcode.BASEFEE:
         op = BlockContextFieldTag.BaseFee
-        ctx_word = instruction.block_context_lookup_word(op)
     elif opcode == Opcode.CHAINID:
         op = BlockContextFieldTag.ChainId
-        ctx_word = Word.from_lo(instruction.block_context_lookup(op))
+    ctx_word = instruction.block_context_lookup_word(op)
 
     # check block table for corresponding op data
     instruction.constrain_equal_word(ctx_word, instruction.stack_push())

--- a/src/zkevm_specs/evm_circuit/execution/caller.py
+++ b/src/zkevm_specs/evm_circuit/execution/caller.py
@@ -7,11 +7,11 @@ def caller(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.CALLER)
 
-    address = instruction.call_context_lookup(CallContextFieldTag.CallerAddress)
+    address_word = instruction.call_context_lookup_word(CallContextFieldTag.CallerAddress)
     # check [rw_table, call_context] table for caller address and compare with
     # stack top after push
     instruction.constrain_equal_word(
-        instruction.address_to_word(address),
+        address_word,
         instruction.stack_push(),
     )
 

--- a/src/zkevm_specs/evm_circuit/execution/callop.py
+++ b/src/zkevm_specs/evm_circuit/execution/callop.py
@@ -51,7 +51,7 @@ def callop(instruction: Instruction):
         is_callcode + is_delegatecall, ctx_caller_address, call.callee_address
     )
     callee_address_word = instruction.address_to_word(callee_address)
-    caller_address_word = instruction.select(
+    caller_address_word = instruction.select_word(
         is_delegatecall, parent_caller_address_word, ctx_caller_address_word
     )
     caller_address = instruction.word_to_address(caller_address_word)

--- a/src/zkevm_specs/evm_circuit/execution/callop.py
+++ b/src/zkevm_specs/evm_circuit/execution/callop.py
@@ -18,19 +18,21 @@ def callop(instruction: Instruction):
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
     reversion_info = instruction.reversion_info()
-    caller_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    ctx_caller_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    ctx_caller_address = instruction.word_to_address(ctx_caller_address_word)
     is_static = instruction.select(
         is_staticcall, FQ(1), instruction.call_context_lookup(CallContextFieldTag.IsStatic)
     )
     depth = instruction.call_context_lookup(CallContextFieldTag.Depth)
-    parent_caller_address, parent_call_value = (
+    parent_caller_address_word, parent_call_value = (
         (
-            instruction.call_context_lookup(CallContextFieldTag.CallerAddress),
+            instruction.call_context_lookup_word(CallContextFieldTag.CallerAddress),
             instruction.call_context_lookup_word(CallContextFieldTag.Value),
         )
         if is_delegatecall == 1
-        else (FQ(0), Word(0))
+        else (Word(0), Word(0))
     )
+    parent_caller_address = instruction.word_to_address(parent_caller_address_word)
 
     # Verify depth is less than 1024
     instruction.range_lookup(depth, 1024)
@@ -44,9 +46,11 @@ def callop(instruction: Instruction):
     # - caller_address = parent_caller_address
     #
     callee_address = instruction.select(
-        is_callcode + is_delegatecall, caller_address, call.callee_address
+        is_callcode + is_delegatecall, ctx_caller_address, call.callee_address
     )
-    caller_address = instruction.select(is_delegatecall, parent_caller_address, caller_address)
+    callee_address_word = instruction.address_to_word(callee_address)
+    caller_address_word = instruction.select(is_delegatecall, parent_caller_address_word, ctx_caller_address_word)
+    caller_address = instruction.word_to_address(caller_address_word)
 
     # Add `callee_address` to access list
     is_warm_access = instruction.add_account_to_access_list(
@@ -183,8 +187,8 @@ def callop(instruction: Instruction):
             (CallContextFieldTag.CallerId, instruction.curr.call_id),
             (CallContextFieldTag.TxId, tx_id.expr()),
             (CallContextFieldTag.Depth, depth.expr() + 1),
-            (CallContextFieldTag.CallerAddress, caller_address.expr()),
-            (CallContextFieldTag.CalleeAddress, callee_address.expr()),
+            (CallContextFieldTag.CallerAddress, caller_address_word),
+            (CallContextFieldTag.CalleeAddress, callee_address_word),
             (CallContextFieldTag.CallDataOffset, call.cd_offset),
             (CallContextFieldTag.CallDataLength, call.cd_length),
             (CallContextFieldTag.ReturnDataOffset, call.rd_offset),

--- a/src/zkevm_specs/evm_circuit/execution/callop.py
+++ b/src/zkevm_specs/evm_circuit/execution/callop.py
@@ -18,7 +18,9 @@ def callop(instruction: Instruction):
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
     reversion_info = instruction.reversion_info()
-    ctx_caller_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    ctx_caller_address_word = instruction.call_context_lookup_word(
+        CallContextFieldTag.CalleeAddress
+    )
     ctx_caller_address = instruction.word_to_address(ctx_caller_address_word)
     is_static = instruction.select(
         is_staticcall, FQ(1), instruction.call_context_lookup(CallContextFieldTag.IsStatic)
@@ -49,7 +51,9 @@ def callop(instruction: Instruction):
         is_callcode + is_delegatecall, ctx_caller_address, call.callee_address
     )
     callee_address_word = instruction.address_to_word(callee_address)
-    caller_address_word = instruction.select(is_delegatecall, parent_caller_address_word, ctx_caller_address_word)
+    caller_address_word = instruction.select(
+        is_delegatecall, parent_caller_address_word, ctx_caller_address_word
+    )
     caller_address = instruction.word_to_address(caller_address_word)
 
     # Add `callee_address` to access list

--- a/src/zkevm_specs/evm_circuit/execution/dataCopy.py
+++ b/src/zkevm_specs/evm_circuit/execution/dataCopy.py
@@ -9,10 +9,12 @@ from ...util import FQ, IdentityBaseGas, IdentityPerWordGas
 
 
 def dataCopy(instruction: Instruction):
+    address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    address = instruction.word_to_address(address_word)
     instruction.fixed_lookup(
         FixedTableTag.PrecompileInfo,
         FQ(instruction.curr.execution_state),
-        instruction.call_context_lookup(CallContextFieldTag.CalleeAddress, RW.Read),
+        address,
         FQ(IdentityBaseGas),
     )
 

--- a/src/zkevm_specs/evm_circuit/execution/end_block.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_block.py
@@ -117,7 +117,9 @@ def end_block(instruction: Instruction):
             # showing that the Tx following the last processed one has
             # CallerAddress = 0x0 (which means padding tx).
             instruction.constrain_equal_word(
-                instruction.tx_context_lookup_word(FQ(total_txs + 1), TxContextFieldTag.CallerAddress),
+                instruction.tx_context_lookup_word(
+                    FQ(total_txs + 1), TxContextFieldTag.CallerAddress
+                ),
                 Word(0),
             )
             # Since every tx lookup done in the EVM circuit must succeed and

--- a/src/zkevm_specs/evm_circuit/execution/end_block.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_block.py
@@ -1,4 +1,4 @@
-from ...util import FQ, N_BYTES_GAS
+from ...util import FQ, N_BYTES_GAS, Word
 from ..instruction import Instruction, Transition
 from ..table import (
     CallContextFieldTag,
@@ -69,7 +69,7 @@ def end_block(instruction: Instruction):
                 tx_row
                 for tx_row in instruction.tables.tx_table
                 if tx_row.field_tag == TxContextFieldTag.CallerAddress
-                and tx_row.value.value().expr() != FQ(0)
+                and (tx_row.value.lo.expr(), tx_row.value.hi.expr()) != (FQ(0), FQ(0))
             ]
         )
     )
@@ -116,9 +116,9 @@ def end_block(instruction: Instruction):
             # Verify that there are at most total_txs meaningful txs in the tx_table, by
             # showing that the Tx following the last processed one has
             # CallerAddress = 0x0 (which means padding tx).
-            instruction.constrain_equal(
-                instruction.tx_context_lookup(FQ(total_txs + 1), TxContextFieldTag.CallerAddress),
-                FQ(0),
+            instruction.constrain_equal_word(
+                instruction.tx_context_lookup_word(FQ(total_txs + 1), TxContextFieldTag.CallerAddress),
+                Word(0),
             )
             # Since every tx lookup done in the EVM circuit must succeed and
             # uses a unique tx_id, we know that at least there are total_tx

--- a/src/zkevm_specs/evm_circuit/execution/end_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_tx.py
@@ -28,7 +28,9 @@ def end_tx(instruction: Instruction):
         tx_gas_price, instruction.curr.gas_left + effective_refund
     )
     instruction.constrain_zero(carry)
-    tx_caller_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CallerAddress)
+    tx_caller_address_word = instruction.tx_context_lookup_word(
+        tx_id, TxContextFieldTag.CallerAddress
+    )
     tx_caller_address = instruction.word_to_address(tx_caller_address_word)
     instruction.add_balance(tx_caller_address, [value])
 

--- a/src/zkevm_specs/evm_circuit/execution/end_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_tx.py
@@ -39,7 +39,8 @@ def end_tx(instruction: Instruction):
     effective_tip, _ = instruction.sub_word(tx_gas_price, base_fee)
     reward, carry = instruction.mul_word_by_u64(effective_tip, gas_used)
     instruction.constrain_zero(carry)
-    coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
+    coinbase_word = instruction.block_context_lookup_word(BlockContextFieldTag.Coinbase)
+    coinbase = instruction.word_to_address(coinbase_word)
     instruction.add_balance(coinbase, [reward])
 
     # constrain tx status matches with `PostStateOrStatus` of TxReceipt tag in RW

--- a/src/zkevm_specs/evm_circuit/execution/end_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_tx.py
@@ -28,7 +28,8 @@ def end_tx(instruction: Instruction):
         tx_gas_price, instruction.curr.gas_left + effective_refund
     )
     instruction.constrain_zero(carry)
-    tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
+    tx_caller_address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CallerAddress)
+    tx_caller_address = instruction.word_to_address(tx_caller_address_word)
     instruction.add_balance(tx_caller_address, [value])
 
     # Add gas_used * effective_tip to coinbase's balance

--- a/src/zkevm_specs/evm_circuit/execution/log.py
+++ b/src/zkevm_specs/evm_circuit/execution/log.py
@@ -24,12 +24,12 @@ def log(instruction: Instruction):
     # check contract_address in CallContext & TxLog
     # use call context's  callee address as contract address
 
-    contract_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    contract_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
     is_persistent = instruction.call_context_lookup(CallContextFieldTag.IsPersistent)
     if instruction.is_zero(is_persistent) == 0:
-        instruction.constrain_equal(
-            contract_address,
-            instruction.tx_log_lookup(
+        instruction.constrain_equal_word(
+            contract_address_word,
+            instruction.tx_log_lookup_word(
                 tx_id=tx_id, log_id=instruction.curr.log_id + 1, field_tag=TxLogFieldTag.Address
             ),
         )

--- a/src/zkevm_specs/evm_circuit/execution/origin.py
+++ b/src/zkevm_specs/evm_circuit/execution/origin.py
@@ -9,9 +9,9 @@ def origin(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.ORIGIN)
 
-    address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
+    address_word = instruction.tx_context_lookup_word(tx_id, TxContextFieldTag.CallerAddress)
     instruction.constrain_equal_word(
-        instruction.address_to_word(address),
+        address_word,
         instruction.stack_push(),
     )
 

--- a/src/zkevm_specs/evm_circuit/execution/return_revert.py
+++ b/src/zkevm_specs/evm_circuit/execution/return_revert.py
@@ -30,7 +30,9 @@ def return_revert(instruction: Instruction):
     if instruction.curr.is_create and is_success:
         # A. Returns the specified memory chunk as deployment code.
 
-        callee_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+        callee_address_word = instruction.call_context_lookup_word(
+            CallContextFieldTag.CalleeAddress
+        )
         callee_address = instruction.word_to_address(callee_address_word)
         code_hash, code_hash_prev = instruction.account_write_word(
             callee_address, AccountFieldTag.CodeHash

--- a/src/zkevm_specs/evm_circuit/execution/return_revert.py
+++ b/src/zkevm_specs/evm_circuit/execution/return_revert.py
@@ -30,7 +30,8 @@ def return_revert(instruction: Instruction):
     if instruction.curr.is_create and is_success:
         # A. Returns the specified memory chunk as deployment code.
 
-        callee_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+        callee_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+        callee_address = instruction.word_to_address(callee_address_word)
         code_hash, code_hash_prev = instruction.account_write_word(
             callee_address, AccountFieldTag.CodeHash
         )

--- a/src/zkevm_specs/evm_circuit/execution/selfbalance.py
+++ b/src/zkevm_specs/evm_circuit/execution/selfbalance.py
@@ -7,7 +7,8 @@ def selfbalance(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.SELFBALANCE)
 
-    callee_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    callee_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    callee_address = instruction.word_to_address(callee_address_word)
     balance = instruction.account_read_word(callee_address, AccountFieldTag.Balance)
     instruction.constrain_equal_word(instruction.stack_push(), balance)
 

--- a/src/zkevm_specs/evm_circuit/execution/storage.py
+++ b/src/zkevm_specs/evm_circuit/execution/storage.py
@@ -18,7 +18,8 @@ def sload(instruction: Instruction):
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
     reversion_info = instruction.reversion_info()
-    callee_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    callee_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    callee_address = instruction.word_to_address(callee_address_word)
 
     storage_key = instruction.stack_pop()
 
@@ -57,7 +58,8 @@ def sstore(instruction: Instruction):
     )
 
     reversion_info = instruction.reversion_info()
-    callee_address = instruction.call_context_lookup(CallContextFieldTag.CalleeAddress)
+    callee_address_word = instruction.call_context_lookup_word(CallContextFieldTag.CalleeAddress)
+    callee_address = instruction.word_to_address(callee_address_word)
 
     storage_key = instruction.stack_pop()
     storage_value = instruction.stack_pop()

--- a/src/zkevm_specs/evm_circuit/typing.py
+++ b/src/zkevm_specs/evm_circuit/typing.py
@@ -110,7 +110,7 @@ class Block:
         value = lambda v: WordOrValue(FQ(v))
         word = lambda w: WordOrValue(Word(w))
         return [
-            BlockTableRow(FQ(BlockContextFieldTag.Coinbase), FQ(0), value(self.coinbase)),
+            BlockTableRow(FQ(BlockContextFieldTag.Coinbase), FQ(0), word(self.coinbase)),
             BlockTableRow(FQ(BlockContextFieldTag.GasLimit), FQ(0), value(self.gas_limit)),
             BlockTableRow(FQ(BlockContextFieldTag.Number), FQ(0), value(self.number)),
             BlockTableRow(FQ(BlockContextFieldTag.Timestamp), FQ(0), value(self.timestamp)),

--- a/src/zkevm_specs/evm_circuit/typing.py
+++ b/src/zkevm_specs/evm_circuit/typing.py
@@ -454,7 +454,12 @@ class RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
         # Sanity checks
-        if field_tag in [CallContextFieldTag.CallerAddress, CallContextFieldTag.CalleeAddress, CallContextFieldTag.Value, CallContextFieldTag.CodeHash]:
+        if field_tag in [
+            CallContextFieldTag.CallerAddress,
+            CallContextFieldTag.CalleeAddress,
+            CallContextFieldTag.Value,
+            CallContextFieldTag.CodeHash,
+        ]:
             assert isinstance(value, Word)
         else:
             assert isinstance(value, FQ)
@@ -468,7 +473,12 @@ class RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
         # Sanity checks
-        if field_tag in [CallContextFieldTag.CallerAddress, CallContextFieldTag.CalleeAddress, CallContextFieldTag.Value, CallContextFieldTag.CodeHash]:
+        if field_tag in [
+            CallContextFieldTag.CallerAddress,
+            CallContextFieldTag.CalleeAddress,
+            CallContextFieldTag.Value,
+            CallContextFieldTag.CodeHash,
+        ]:
             assert isinstance(value, Word)
         else:
             assert isinstance(value, FQ)

--- a/src/zkevm_specs/evm_circuit/typing.py
+++ b/src/zkevm_specs/evm_circuit/typing.py
@@ -209,13 +209,13 @@ class Transaction:
                 word(self.gas_price),
             ),
             TxTableRow(
-                FQ(self.id), FQ(TxContextFieldTag.CallerAddress), FQ(0), value(self.caller_address)
+                FQ(self.id), FQ(TxContextFieldTag.CallerAddress), FQ(0), word(self.caller_address)
             ),
             TxTableRow(
                 FQ(self.id),
                 FQ(TxContextFieldTag.CalleeAddress),
                 FQ(0),
-                value(0 if self.callee_address is None else self.callee_address),
+                word(0 if self.callee_address is None else self.callee_address),
             ),
             TxTableRow(
                 FQ(self.id),
@@ -453,6 +453,11 @@ class RWDictionary:
     ) -> RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
+        # Sanity checks
+        if field_tag in [CallContextFieldTag.CallerAddress, CallContextFieldTag.CalleeAddress, CallContextFieldTag.Value, CallContextFieldTag.CodeHash]:
+            assert isinstance(value, Word)
+        else:
+            assert isinstance(value, FQ)
         return self._append(
             RW.Read, RWTableTag.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
         )
@@ -462,6 +467,11 @@ class RWDictionary:
     ) -> RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
+        # Sanity checks
+        if field_tag in [CallContextFieldTag.CallerAddress, CallContextFieldTag.CalleeAddress, CallContextFieldTag.Value, CallContextFieldTag.CodeHash]:
+            assert isinstance(value, Word)
+        else:
+            assert isinstance(value, FQ)
         return self._append(
             RW.Write, RWTableTag.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
         )
@@ -476,6 +486,11 @@ class RWDictionary:
     ) -> RWDictionary:
         if isinstance(value, int):
             value = FQ(value)
+        # Sanity checks
+        if field_tag in [TxLogFieldTag.Address, TxLogFieldTag.Topic]:
+            assert isinstance(value, Word)
+        else:
+            assert isinstance(value, FQ)
         return self._append(
             RW.Write,
             RWTableTag.TxLog,

--- a/tests/evm/test_address.py
+++ b/tests/evm/test_address.py
@@ -25,7 +25,6 @@ TESTING_DATA = (
 def test_address(address: U160):
     bytecode = Bytecode().address()
     bytecode_hash = Word(bytecode.hash())
-    address_word = Word(address)
 
     tables = Tables(
         block_table=set(),
@@ -33,8 +32,8 @@ def test_address(address: U160):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, address_word)
-            .stack_write(1, 1023, address_word)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(address))
+            .stack_write(1, 1023, Word(address))
             .rws
         ),
     )

--- a/tests/evm/test_address.py
+++ b/tests/evm/test_address.py
@@ -25,6 +25,7 @@ TESTING_DATA = (
 def test_address(address: U160):
     bytecode = Bytecode().address()
     bytecode_hash = Word(bytecode.hash())
+    address_word = Word(address)
 
     tables = Tables(
         block_table=set(),
@@ -32,8 +33,8 @@ def test_address(address: U160):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, address)
-            .stack_write(1, 1023, Word(address))
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, address_word)
+            .stack_write(1, 1023, address_word)
             .rws
         ),
     )

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -189,8 +189,8 @@ def test_begin_tx(tx: Transaction, callee: Account, is_success: bool):
     if callee.code_hash() != EMPTY_CODE_HASH and is_tx_valid == 1:
         rw_dictionary \
         .call_context_read(1, CallContextFieldTag.Depth, 1) \
-        .call_context_read(1, CallContextFieldTag.CallerAddress, tx.caller_address) \
-        .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address) \
+        .call_context_read(1, CallContextFieldTag.CallerAddress, Word(tx.caller_address)) \
+        .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(tx.callee_address)) \
         .call_context_read(1, CallContextFieldTag.CallDataOffset, 0) \
         .call_context_read(1, CallContextFieldTag.CallDataLength, len(tx.call_data)) \
         .call_context_read(1, CallContextFieldTag.Value, Word(tx.value)) \

--- a/tests/evm/test_caller.py
+++ b/tests/evm/test_caller.py
@@ -26,6 +26,7 @@ TESTING_DATA = (
 def test_caller(caller: U160):
     bytecode = Bytecode().caller()
     bytecode_hash = Word(bytecode.hash())
+    caller_word = Word(caller)
 
     tables = Tables(
         block_table=set(),
@@ -33,8 +34,8 @@ def test_caller(caller: U160):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CallerAddress, caller)
-            .stack_write(1, 1023, Word(caller))
+            .call_context_read(1, CallContextFieldTag.CallerAddress, caller_word)
+            .stack_write(1, 1023, caller_word)
             .rws
         ),
     )

--- a/tests/evm/test_caller.py
+++ b/tests/evm/test_caller.py
@@ -26,7 +26,6 @@ TESTING_DATA = (
 def test_caller(caller: U160):
     bytecode = Bytecode().caller()
     bytecode_hash = Word(bytecode.hash())
-    caller_word = Word(caller)
 
     tables = Tables(
         block_table=set(),
@@ -34,8 +33,8 @@ def test_caller(caller: U160):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CallerAddress, caller_word)
-            .stack_write(1, 1023, caller_word)
+            .call_context_read(1, CallContextFieldTag.CallerAddress, Word(caller))
+            .stack_write(1, 1023, Word(caller))
             .rws
         ),
     )

--- a/tests/evm/test_callop.py
+++ b/tests/evm/test_callop.py
@@ -286,13 +286,13 @@ def test_callop(
         .call_context_read(1, CallContextFieldTag.TxId, 1)
         .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, caller_ctx.rw_counter_end_of_reversion)
         .call_context_read(1, CallContextFieldTag.IsPersistent, caller_ctx.is_persistent)
-        .call_context_read(1, CallContextFieldTag.CalleeAddress, caller.address)
+        .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(caller.address))
         .call_context_read(1, CallContextFieldTag.IsStatic, is_static)
         .call_context_read(1, CallContextFieldTag.Depth, 1)
     )
     if is_delegatecall == 1:
         rw_dictionary \
-        .call_context_read(1, CallContextFieldTag.CallerAddress, parent_caller.address) \
+        .call_context_read(1, CallContextFieldTag.CallerAddress, Word(parent_caller.address)) \
         .call_context_read(1, CallContextFieldTag.Value, Word(parent_value))
     if is_call + is_callcode == 1:
         rw_dictionary \
@@ -359,8 +359,8 @@ def test_callop(
         .call_context_read(call_id, CallContextFieldTag.CallerId, 1) \
         .call_context_read(call_id, CallContextFieldTag.TxId, 1) \
         .call_context_read(call_id, CallContextFieldTag.Depth, 2) \
-        .call_context_read(call_id, CallContextFieldTag.CallerAddress, caller.address) \
-        .call_context_read(call_id, CallContextFieldTag.CalleeAddress, callee.address) \
+        .call_context_read(call_id, CallContextFieldTag.CallerAddress, Word(caller.address)) \
+        .call_context_read(call_id, CallContextFieldTag.CalleeAddress, Word(callee.address)) \
         .call_context_read(call_id, CallContextFieldTag.CallDataOffset, stack.cd_offset if stack.cd_length != 0 else 0) \
         .call_context_read(call_id, CallContextFieldTag.CallDataLength, stack.cd_length) \
         .call_context_read(call_id, CallContextFieldTag.ReturnDataOffset, stack.rd_offset if stack.rd_length != 0 else 0) \

--- a/tests/evm/test_create.py
+++ b/tests/evm/test_create.py
@@ -282,7 +282,7 @@ def test_create_create2(
     rw_dictionary \
         .call_context_read(CURRENT_CALL_ID, CallContextFieldTag.Depth, stack_depth) \
         .call_context_read(CURRENT_CALL_ID, CallContextFieldTag.TxId, 1) \
-        .call_context_read(CURRENT_CALL_ID, CallContextFieldTag.CallerAddress, caller.address) \
+        .call_context_read(CURRENT_CALL_ID, CallContextFieldTag.CallerAddress, Word(caller.address)) \
         .account_write(caller.address, AccountFieldTag.Nonce, nonce, nonce - 1) \
         .account_write(caller.address, AccountFieldTag.Balance, caller_balance, caller_balance_prev) \
         .call_context_read(CURRENT_CALL_ID, CallContextFieldTag.IsSuccess, is_success) \
@@ -334,8 +334,8 @@ def test_create_create2(
             .call_context_read(next_call_id, CallContextFieldTag.CallerId, CURRENT_CALL_ID) \
             .call_context_read(next_call_id, CallContextFieldTag.TxId, 1) \
             .call_context_read(next_call_id, CallContextFieldTag.Depth, stack_depth+1) \
-            .call_context_read(next_call_id, CallContextFieldTag.CallerAddress, caller.address) \
-            .call_context_read(next_call_id, CallContextFieldTag.CalleeAddress, contract_address) \
+            .call_context_read(next_call_id, CallContextFieldTag.CallerAddress, Word(caller.address)) \
+            .call_context_read(next_call_id, CallContextFieldTag.CalleeAddress, Word(contract_address)) \
             .call_context_read(next_call_id, CallContextFieldTag.IsSuccess, is_success) \
             .call_context_read(next_call_id, CallContextFieldTag.IsStatic, is_static) \
             .call_context_read(next_call_id, CallContextFieldTag.IsRoot, False) \

--- a/tests/evm/test_dataCopy.py
+++ b/tests/evm/test_dataCopy.py
@@ -70,7 +70,7 @@ def test_dataCopy(
     rw_dictionary = (
         # fmt: off
         RWDictionary(1)
-        .call_context_read(precompile_id, CallContextFieldTag.CalleeAddress, DATACOPY_PRECOMPILE_ADDRESS)
+        .call_context_read(precompile_id, CallContextFieldTag.CalleeAddress, Word(DATACOPY_PRECOMPILE_ADDRESS))
         .call_context_read(precompile_id, CallContextFieldTag.CallerId, call_id)
         .call_context_read(precompile_id, CallContextFieldTag.CallDataOffset, call_data_offset)
         .call_context_read(precompile_id, CallContextFieldTag.CallDataLength, call_data_length)

--- a/tests/evm/test_logs.py
+++ b/tests/evm/test_logs.py
@@ -123,12 +123,12 @@ def make_log(
         .stack_read(CALL_ID, stack_pointer + 1, Word(msize))
         .call_context_read(CALL_ID, CallContextFieldTag.TxId, TX_ID)
         .call_context_read(CALL_ID, CallContextFieldTag.IsStatic, 0)
-        .call_context_read(CALL_ID, CallContextFieldTag.CalleeAddress, FQ(CALLEE_ADDRESS))
+        .call_context_read(CALL_ID, CallContextFieldTag.CalleeAddress, Word(CALLEE_ADDRESS))
         .call_context_read(CALL_ID, CallContextFieldTag.IsPersistent, is_persistent)
     )
 
     if is_persistent:
-        rw_dictionary.tx_log_write(TX_ID, log_id, TxLogFieldTag.Address, 0, FQ(CALLEE_ADDRESS))
+        rw_dictionary.tx_log_write(TX_ID, log_id, TxLogFieldTag.Address, 0, Word(CALLEE_ADDRESS))
 
     # append topic rows
     construct_topic_rws(rw_dictionary, log_id, stack_pointer + 2, topics, is_persistent)

--- a/tests/evm/test_return_revert.py
+++ b/tests/evm/test_return_revert.py
@@ -155,7 +155,7 @@ def test_is_create(
         .call_context_read(callee_id, CallContextFieldTag.IsSuccess, int(is_return))
         .stack_read(callee_id, 1022, return_offset_word)
         .stack_read(callee_id, 1023, return_length_word)
-        .call_context_read(callee_id, CallContextFieldTag.CalleeAddress, int(CALLEE_ADDRESS))
+        .call_context_read(callee_id, CallContextFieldTag.CalleeAddress, Word(CALLEE_ADDRESS))
         .account_write(
             CALLEE_ADDRESS,
             AccountFieldTag.CodeHash,

--- a/tests/evm/test_selfbalance.py
+++ b/tests/evm/test_selfbalance.py
@@ -22,6 +22,7 @@ TESTING_DATA = [(0, 0), (0, 10), (rand_address(), rand_word())]
 def test_selfbalance(callee_address: U160, balance: U256):
     bytecode = Bytecode().selfbalance()
     bytecode_hash = Word(bytecode.hash())
+    callee_address_word = Word(callee_address)
 
     tables = Tables(
         block_table=Block(),
@@ -29,7 +30,7 @@ def test_selfbalance(callee_address: U160, balance: U256):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, callee_address)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, callee_address_word)
             .account_read(callee_address, AccountFieldTag.Balance, Word(balance))
             .stack_write(1, 1023, Word(balance))
             .rws

--- a/tests/evm/test_selfbalance.py
+++ b/tests/evm/test_selfbalance.py
@@ -22,7 +22,6 @@ TESTING_DATA = [(0, 0), (0, 10), (rand_address(), rand_word())]
 def test_selfbalance(callee_address: U160, balance: U256):
     bytecode = Bytecode().selfbalance()
     bytecode_hash = Word(bytecode.hash())
-    callee_address_word = Word(callee_address)
 
     tables = Tables(
         block_table=Block(),
@@ -30,7 +29,7 @@ def test_selfbalance(callee_address: U160, balance: U256):
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(
             RWDictionary(9)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, callee_address_word)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(callee_address))
             .account_read(callee_address, AccountFieldTag.Balance, Word(balance))
             .stack_write(1, 1023, Word(balance))
             .rws

--- a/tests/evm/test_sload.py
+++ b/tests/evm/test_sload.py
@@ -66,7 +66,7 @@ def test_sload(tx: Transaction, storage_key_be_bytes: bytes, warm: bool, is_pers
             .call_context_read(1, CallContextFieldTag.TxId, tx.id)
             .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_persistent else rw_counter_end_of_reversion)
             .call_context_read(1, CallContextFieldTag.IsPersistent, is_persistent)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(tx.callee_address))
             .stack_read(1, 1023, storage_key)
             .account_storage_read(tx.callee_address, storage_key, value, tx.id, value_committed)
             .stack_write(1, 1023, value)

--- a/tests/evm/test_sstore.py
+++ b/tests/evm/test_sstore.py
@@ -139,7 +139,7 @@ def test_sstore(
             .call_context_read(1, CallContextFieldTag.IsStatic, 0)
             .call_context_read(1, CallContextFieldTag.RwCounterEndOfReversion, 0 if is_success else 14)
             .call_context_read(1, CallContextFieldTag.IsPersistent, is_success)
-            .call_context_read(1, CallContextFieldTag.CalleeAddress, tx.callee_address)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, Word(tx.callee_address))
             .stack_read(1, 1022, Word(storage_key))
             .stack_read(1, 1023, Word(value))
             .account_storage_write(tx.callee_address, Word(storage_key), Word(value), Word(value_prev), tx.id, Word(value_committed), rw_counter_of_reversion=None if is_success else 14)


### PR DESCRIPTION
When encoding an Address into columns that support Words and other types, split the Address into lo/hi instead of keeping the whole word in the lo part.  This makes it easier to reason about always having lo/hi values be at most 128 bits.

Resolve https://github.com/privacy-scaling-explorations/zkevm-specs/issues/423

Note that we still have some Address encoded as a single field.  This happens for example:
- In the RwTable we use Address key as single field value in `TxAccessListAccount`, `TxAccessListAccountStorage`, `Account`, `AccountStorage`
- The MPT Table each proof type has an `Address` key field

This means we still have some conversion from Address as Word to Address as Field and vice versa.  Nevertheless I think favoring  Address as Word where possible is more optimal, because when we have an Address as Word type checked, we can just do `address_word.lo + address_word.hi * 2^128` to get a type checked Address as Field; whereas the other way around (splitting) requires range checks.