### PR TITLE
Changed name of RwTableTag to Target (#422)

### DIFF
--- a/specs/tables.md
+++ b/specs/tables.md
@@ -82,7 +82,7 @@ DELETEME: Review note: Removed aux1 and aux2 and instead added InitialValue whic
 
 | 0 *Rwc*  | 1 *IsWrite* | 2 *Tag* k0                 | 3 *Id* k1 | 4 *Address* k2     | 5 *FieldTag* k3            | 6,7 *StoKey{Lo,Hi}* k4,k5 | 7,8 *Val{Lo,Hi}* | 9,10 *ValPrev{Lo,Hi}* | 11,12 *InitVal{Lo,Hi}* |
 | -------- | ----------- | -------------------------- | --------  | --------           | -------------------------- | ------------------------- | ---------------- | --------------------- | ---------------------- |
-|          |             | *RwTableTag*               |           |                    |                            |                           |                  |                       |                        |
+|          |             | *Target*               |           |                    |                            |                           |                  |                       |                        |
 | $counter | true        | TxAccessListAccount        | $txID     | $address           |                            |                           | $val,0           | $valPrev,0            |                        |
 | $counter | true        | TxAccessListAccountStorage | $txID     | $address           |                            | $storageKey{Lo,Hi}        | $val,0           | $valPrev,0            |                        |
 | $counter | $isWrite    | TxRefund                   | $txID     |                    |                            |                           | $val,0           | $valPrev,0            |                        |

--- a/src/zkevm_specs/copy_circuit.py
+++ b/src/zkevm_specs/copy_circuit.py
@@ -6,7 +6,7 @@ from .evm_circuit import (
     CopyDataTypeTag,
     CopyCircuitRow,
     RW,
-    RWTableTag,
+    Target,
     CopyCircuit,
     TxContextFieldTag,
     BytecodeFieldTag,
@@ -106,7 +106,7 @@ def verify_copy_table(copy_circuit: CopyCircuit, tables: Tables, r: FQ):
         # lookup into tables
         if row.is_memory == 1 and row.is_pad == 0:
             val = tables.rw_lookup(
-                row.rw_counter, 1 - row.q_step, FQ(RWTableTag.Memory), row.id.value(), row.addr
+                row.rw_counter, 1 - row.q_step, FQ(Target.Memory), row.id.value(), row.addr
             ).value.value()
             cs.constrain_equal(val, row.value)
         if row.is_bytecode == 1 and row.is_pad == 0:
@@ -123,7 +123,7 @@ def verify_copy_table(copy_circuit: CopyCircuit, tables: Tables, r: FQ):
             val = tables.rw_lookup(
                 row.rw_counter,
                 FQ(RW.Write),
-                FQ(RWTableTag.TxLog),
+                FQ(Target.TxLog),
                 row.id.value(),  # tx_id
                 row.addr,
             ).value.value()

--- a/src/zkevm_specs/evm_circuit/instruction.py
+++ b/src/zkevm_specs/evm_circuit/instruction.py
@@ -41,7 +41,7 @@ from .table import (
     FixedTableTag,
     TxContextFieldTag,
     RW,
-    RWTableTag,
+    Target,
     TxLogFieldTag,
     TxReceiptFieldTag,
     CopyDataTypeTag,
@@ -694,7 +694,7 @@ class Instruction:
         # evm only write tx log
         value = self.rw_lookup(
             RW.Write,
-            RWTableTag.TxLog,
+            Target.TxLog,
             id=tx_id,
             address=FQ(index + (int(field_tag) << 32) + (log_id.expr().n << 48)),
             field_tag=FQ(0),
@@ -711,7 +711,7 @@ class Instruction:
     ) -> Expression:
         value = self.rw_lookup(
             RW.Read,
-            RWTableTag.TxReceipt,
+            Target.TxReceipt,
             id=tx_id,
             address=FQ(0),
             field_tag=FQ(field_tag),
@@ -728,7 +728,7 @@ class Instruction:
     ) -> Expression:
         value = self.rw_lookup(
             RW.Write,
-            RWTableTag.TxReceipt,
+            Target.TxReceipt,
             id=tx_id,
             address=FQ(0),
             field_tag=FQ(field_tag),
@@ -775,7 +775,7 @@ class Instruction:
     def rw_lookup(
         self,
         rw: RW,
-        tag: RWTableTag,
+        tag: Target,
         id: Optional[Expression] = None,
         address: Optional[Expression] = None,
         field_tag: Optional[Expression] = None,
@@ -808,7 +808,7 @@ class Instruction:
 
     def state_write(
         self,
-        tag: RWTableTag,
+        tag: Target,
         id: Optional[Expression] = None,
         address: Optional[Expression] = None,
         field_tag: Optional[Expression] = None,
@@ -847,7 +847,7 @@ class Instruction:
 
     def state_read(
         self,
-        tag: RWTableTag,
+        tag: Target,
         id: Optional[Expression] = None,
         address: Optional[Expression] = None,
         field_tag: Optional[Expression] = None,
@@ -875,11 +875,11 @@ class Instruction:
     ) -> WordOrValue:
         if call_id is None:
             call_id = self.curr.call_id
-        return self.rw_lookup(rw, RWTableTag.CallContext, call_id, FQ(field_tag)).value
+        return self.rw_lookup(rw, Target.CallContext, call_id, FQ(field_tag)).value
 
     def rw_table_start_lookup(self, counter: Expression):
         # Raises exception if no lookup matches
-        self.rw_lookup(rw=RW.Read, tag=RWTableTag.Start, rw_counter=counter)
+        self.rw_lookup(rw=RW.Read, tag=Target.Start, rw_counter=counter)
 
     def reversion_info(self, call_id: Optional[Expression] = None) -> ReversionInfo:
         [rw_counter_end_of_reversion, is_persistent] = [
@@ -906,7 +906,7 @@ class Instruction:
 
     def stack_lookup(self, rw: RW, stack_pointer_offset: Expression) -> Word:
         stack_pointer = self.curr.stack_pointer + stack_pointer_offset
-        return self.rw_lookup(rw, RWTableTag.Stack, self.curr.call_id, stack_pointer).value
+        return self.rw_lookup(rw, Target.Stack, self.curr.call_id, stack_pointer).value
 
     def memory_lookup(
         self, rw: RW, memory_address: Expression, call_id: Optional[Expression] = None
@@ -914,11 +914,11 @@ class Instruction:
         if call_id is None:
             call_id = self.curr.call_id
         return cast_expr(
-            self.rw_lookup(rw, RWTableTag.Memory, call_id, memory_address).value.value(), FQ
+            self.rw_lookup(rw, Target.Memory, call_id, memory_address).value.value(), FQ
         )
 
     def tx_refund_read(self, tx_id: Expression) -> FQ:
-        return cast_expr(self.rw_lookup(RW.Read, RWTableTag.TxRefund, tx_id).value.value(), FQ)
+        return cast_expr(self.rw_lookup(RW.Read, Target.TxRefund, tx_id).value.value(), FQ)
 
     def tx_refund_write(
         self,
@@ -926,7 +926,7 @@ class Instruction:
         reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[FQ, FQ]:
         row = self.state_write(
-            RWTableTag.TxRefund,
+            Target.TxRefund,
             tx_id,
             reversion_info=reversion_info,
         )
@@ -941,7 +941,7 @@ class Instruction:
         self, account_address: Expression, account_field_tag: AccountFieldTag
     ) -> WordOrValue:
         return self.rw_lookup(
-            RW.Read, RWTableTag.Account, address=account_address, field_tag=FQ(account_field_tag)
+            RW.Read, Target.Account, address=account_address, field_tag=FQ(account_field_tag)
         ).value
 
     def account_write(
@@ -960,7 +960,7 @@ class Instruction:
         reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[WordOrValue, WordOrValue]:
         row = self.state_write(
-            RWTableTag.Account,
+            Target.Account,
             address=account_address,
             field_tag=FQ(account_field_tag),
             reversion_info=reversion_info,
@@ -1000,7 +1000,7 @@ class Instruction:
     ) -> Word:
         row = self.rw_lookup(
             RW.Read,
-            RWTableTag.AccountStorage,
+            Target.AccountStorage,
             tx_id,
             account_address,
             field_tag=None,
@@ -1016,7 +1016,7 @@ class Instruction:
         reversion_info: Optional[ReversionInfo] = None,
     ) -> Tuple[Word, Word, Word]:
         row = self.state_write(
-            RWTableTag.AccountStorage,
+            Target.AccountStorage,
             tx_id,
             account_address,
             storage_key=storage_key,
@@ -1031,7 +1031,7 @@ class Instruction:
         reversion_info: Optional[ReversionInfo] = None,
     ) -> FQ:
         row = self.state_write(
-            RWTableTag.TxAccessListAccount,
+            Target.TxAccessListAccount,
             tx_id,
             account_address,
             value=FQ(1),
@@ -1045,7 +1045,7 @@ class Instruction:
         account_address: Expression,
     ) -> FQ:
         row = self.state_read(
-            RWTableTag.TxAccessListAccount,
+            Target.TxAccessListAccount,
             tx_id,
             account_address,
         )
@@ -1059,7 +1059,7 @@ class Instruction:
         reversion_info: Optional[ReversionInfo] = None,
     ) -> FQ:
         row = self.state_write(
-            RWTableTag.TxAccessListAccountStorage,
+            Target.TxAccessListAccountStorage,
             tx_id,
             account_address,
             storage_key=storage_key,

--- a/src/zkevm_specs/evm_circuit/table.py
+++ b/src/zkevm_specs/evm_circuit/table.py
@@ -180,7 +180,7 @@ class RW(IntEnum):
     Write = 1
 
 
-class RWTableTag(IntEnum):
+class Target(IntEnum):
     """
     Tag for RWTable lookup, where the RWTable an advice-column table built by
     prover, which will be part of State circuit and each unit read-write data
@@ -206,11 +206,11 @@ class RWTableTag(IntEnum):
     # to write them with reversion when the write might fail.
     def write_with_reversion(self) -> bool:
         return self in [
-            RWTableTag.TxAccessListAccount,
-            RWTableTag.TxAccessListAccountStorage,
-            RWTableTag.Account,
-            RWTableTag.AccountStorage,
-            RWTableTag.TxRefund,
+            Target.TxAccessListAccount,
+            Target.TxAccessListAccountStorage,
+            Target.Account,
+            Target.AccountStorage,
+            Target.TxRefund,
         ]
 
 
@@ -263,7 +263,7 @@ class CallContextFieldTag(IntEnum):
     # CallState in the end by callee.
     # Note that stack and memory could also be included here, but since they
     # need extra constraints on their data format, so we separate them to be
-    # different kinds of RWTableTag.
+    # different kinds of Target.
     ProgramCounter = auto()
     StackPointer = auto()
     GasLeft = auto()
@@ -427,7 +427,7 @@ class BytecodeTableRow(TableRow):
 class RWTableRow(TableRow):
     rw_counter: Expression
     rw: Expression
-    key0: Expression  # RWTableTag
+    key0: Expression  # Target
     id: Expression = field(default=FQ(0))
     address: Expression = field(default=FQ(0))
     field_tag: Expression = field(default=FQ(0))

--- a/src/zkevm_specs/evm_circuit/typing.py
+++ b/src/zkevm_specs/evm_circuit/typing.py
@@ -43,7 +43,7 @@ from .table import (
     BytecodeTableRow,
     CallContextFieldTag,
     RWTableRow,
-    RWTableTag,
+    Target,
     TxContextFieldTag,
     TxLogFieldTag,
     TxReceiptFieldTag,
@@ -428,24 +428,24 @@ class RWDictionary:
 
     def stack_read(self, call_id: IntOrFQ, stack_pointer: IntOrFQ, value: Word) -> RWDictionary:
         return self._append(
-            RW.Read, RWTableTag.Stack, id=FQ(call_id), address=FQ(stack_pointer), value=value
+            RW.Read, Target.Stack, id=FQ(call_id), address=FQ(stack_pointer), value=value
         )
 
     def stack_write(self, call_id: IntOrFQ, stack_pointer: IntOrFQ, value: Word) -> RWDictionary:
         return self._append(
-            RW.Write, RWTableTag.Stack, id=FQ(call_id), address=FQ(stack_pointer), value=value
+            RW.Write, Target.Stack, id=FQ(call_id), address=FQ(stack_pointer), value=value
         )
 
     def memory_read(self, call_id: IntOrFQ, memory_address: IntOrFQ, byte: IntOrFQ) -> RWDictionary:
         return self._append(
-            RW.Read, RWTableTag.Memory, id=FQ(call_id), address=FQ(memory_address), value=FQ(byte)
+            RW.Read, Target.Memory, id=FQ(call_id), address=FQ(memory_address), value=FQ(byte)
         )
 
     def memory_write(
         self, call_id: IntOrFQ, memory_address: IntOrFQ, byte: IntOrFQ
     ) -> RWDictionary:
         return self._append(
-            RW.Write, RWTableTag.Memory, id=FQ(call_id), address=FQ(memory_address), value=FQ(byte)
+            RW.Write, Target.Memory, id=FQ(call_id), address=FQ(memory_address), value=FQ(byte)
         )
 
     def call_context_read(
@@ -464,7 +464,7 @@ class RWDictionary:
         else:
             assert isinstance(value, FQ)
         return self._append(
-            RW.Read, RWTableTag.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
+            RW.Read, Target.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
         )
 
     def call_context_write(
@@ -483,7 +483,7 @@ class RWDictionary:
         else:
             assert isinstance(value, FQ)
         return self._append(
-            RW.Write, RWTableTag.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
+            RW.Write, Target.CallContext, id=FQ(call_id), address=FQ(field_tag), value=value
         )
 
     def tx_log_write(
@@ -503,7 +503,7 @@ class RWDictionary:
             assert isinstance(value, FQ)
         return self._append(
             RW.Write,
-            RWTableTag.TxLog,
+            Target.TxLog,
             id=FQ(tx_id),
             address=FQ(index + (int(field_tag) << 32) + (log_id << 48)),
             field_tag=FQ(0),
@@ -519,7 +519,7 @@ class RWDictionary:
     ) -> RWDictionary:
         return self._append(
             RW.Read,
-            RWTableTag.TxReceipt,
+            Target.TxReceipt,
             id=FQ(tx_id),
             field_tag=FQ(field_tag),
             value=FQ(value),
@@ -533,7 +533,7 @@ class RWDictionary:
     ) -> RWDictionary:
         return self._append(
             RW.Write,
-            RWTableTag.TxReceipt,
+            Target.TxReceipt,
             id=FQ(tx_id),
             field_tag=FQ(field_tag),
             value=FQ(value),
@@ -541,7 +541,7 @@ class RWDictionary:
 
     def tx_refund_read(self, tx_id: IntOrFQ, refund: IntOrFQ) -> RWDictionary:
         return self._append(
-            RW.Read, RWTableTag.TxRefund, id=FQ(tx_id), value=FQ(refund), value_prev=FQ(refund)
+            RW.Read, Target.TxRefund, id=FQ(tx_id), value=FQ(refund), value_prev=FQ(refund)
         )
 
     def tx_refund_write(
@@ -552,7 +552,7 @@ class RWDictionary:
         rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
-            RWTableTag.TxRefund,
+            Target.TxRefund,
             id=FQ(tx_id),
             value=FQ(refund),
             value_prev=FQ(refund_prev),
@@ -568,7 +568,7 @@ class RWDictionary:
         rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
-            RWTableTag.TxAccessListAccount,
+            Target.TxAccessListAccount,
             id=FQ(tx_id),
             address=FQ(account_address),
             value=FQ(value),
@@ -583,7 +583,7 @@ class RWDictionary:
         value: bool,
     ) -> RWDictionary:
         return self._state_read(
-            RWTableTag.TxAccessListAccount,
+            Target.TxAccessListAccount,
             id=FQ(tx_id),
             address=FQ(account_address),
             value=FQ(value),
@@ -600,7 +600,7 @@ class RWDictionary:
         rw_counter_of_reversion: Optional[int] = None,
     ) -> RWDictionary:
         return self._state_write(
-            RWTableTag.TxAccessListAccountStorage,
+            Target.TxAccessListAccountStorage,
             id=FQ(tx_id),
             address=FQ(account_address),
             storage_key=storage_key,
@@ -616,7 +616,7 @@ class RWDictionary:
             value = FQ(value)
         return self._append(
             RW.Read,
-            RWTableTag.Account,
+            Target.Account,
             address=FQ(account_address),
             field_tag=FQ(field_tag),
             value=value,
@@ -636,7 +636,7 @@ class RWDictionary:
         if isinstance(value_prev, int):
             value_prev = FQ(value_prev)
         return self._state_write(
-            RWTableTag.Account,
+            Target.Account,
             address=FQ(account_address),
             field_tag=FQ(field_tag),
             value=value,
@@ -656,7 +656,7 @@ class RWDictionary:
             tx_id = FQ(tx_id)
         return self._append(
             RW.Read,
-            RWTableTag.AccountStorage,
+            Target.AccountStorage,
             id=tx_id,
             address=FQ(account_address),
             storage_key=storage_key,
@@ -678,7 +678,7 @@ class RWDictionary:
         if isinstance(tx_id, int):
             tx_id = FQ(tx_id)
         return self._state_write(
-            RWTableTag.AccountStorage,
+            Target.AccountStorage,
             id=tx_id,
             address=FQ(account_address),
             storage_key=storage_key,
@@ -690,7 +690,7 @@ class RWDictionary:
 
     def _state_write(
         self,
-        tag: RWTableTag,
+        tag: Target,
         id: Expression = FQ(0),
         address: Expression = FQ(0),
         field_tag: Expression = FQ(0),
@@ -730,7 +730,7 @@ class RWDictionary:
 
     def _state_read(
         self,
-        tag: RWTableTag,
+        tag: Target,
         id: Expression = FQ(0),
         address: Expression = FQ(0),
         field_tag: Expression = FQ(0),
@@ -754,7 +754,7 @@ class RWDictionary:
     def _append(
         self,
         rw: RW,
-        tag: RWTableTag,
+        tag: Target,
         id: Expression = FQ(0),
         address: Expression = FQ(0),
         field_tag: Expression = FQ(0),

--- a/tests/evm/test_end_block.py
+++ b/tests/evm/test_end_block.py
@@ -5,7 +5,7 @@ from zkevm_specs.evm_circuit import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
+    Target,
     RWTableRow,
     RW,
     CallContextFieldTag,
@@ -49,7 +49,7 @@ def test_end_block(
                 RWTableRow(
                     FQ(22),
                     FQ(RW.Read),
-                    key0=FQ(RWTableTag.CallContext),
+                    key0=FQ(Target.CallContext),
                     id=FQ(1),
                     address=FQ(3),
                     field_tag=FQ(CallContextFieldTag.TxId),
@@ -61,7 +61,7 @@ def test_end_block(
                 RWTableRow(
                     FQ(23),
                     FQ(RW.Read),
-                    key0=FQ(RWTableTag.TxReceipt),
+                    key0=FQ(Target.TxReceipt),
                     id=FQ(tx.id),
                     address=FQ(0),
                     field_tag=FQ(TxReceiptFieldTag.CumulativeGasUsed),
@@ -71,7 +71,7 @@ def test_end_block(
             )
 
     rw_padding = [
-        RWTableRow(FQ(i + 1), FQ(0), FQ(RWTableTag.Start)) for i in range(MAX_RWS - len(rw_rows))
+        RWTableRow(FQ(i + 1), FQ(0), FQ(Target.Start)) for i in range(MAX_RWS - len(rw_rows))
     ]
 
     num_txs = 0 if empty_block else 1


### PR DESCRIPTION
### Changed name of RwTableTag to Target in the files stated in the issue#422

> 

These files are:
- src/zkevm_specs/evm_circuit/table.py
- src/zkevm_specs/evm_circuit/typing.py
- src/zkevm_specs/evm_circuit/instruction.py
- src/zkevm_specs_/copy_circuit.py
- specs/tables.md
- tests/evm/test_end_block.py

No other appearance of RwTableTag found. RwTable stayed untouched.