### PR TITLE
refactor `mul_word_by_u64` gadget

### DIFF
--- a/src/zkevm_specs/evm_circuit/execution/begin_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/begin_tx.py
@@ -52,8 +52,7 @@ def begin_tx(instruction: Instruction):
     # Calculate gas fee
     tx_gas = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Gas)
     tx_gas_price = instruction.tx_gas_price(tx_id)
-    gas_fee, carry = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
-    instruction.constrain_zero(carry)
+    gas_fee = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
 
     # intrinsic gas
     # G_0 = sum([G_txdatazero if CallData[i] == 0 else G_txdatanonzero for i in len(CallData)]) +

--- a/src/zkevm_specs/evm_circuit/execution/end_tx.py
+++ b/src/zkevm_specs/evm_circuit/execution/end_tx.py
@@ -24,10 +24,7 @@ def end_tx(instruction: Instruction):
 
     # Add effective_refund * gas_price back to caller's balance
     tx_gas_price = instruction.tx_gas_price(tx_id)
-    value, carry = instruction.mul_word_by_u64(
-        tx_gas_price, instruction.curr.gas_left + effective_refund
-    )
-    instruction.constrain_zero(carry)
+    value = instruction.mul_word_by_u64(tx_gas_price, instruction.curr.gas_left + effective_refund)
     tx_caller_address_word = instruction.tx_context_lookup_word(
         tx_id, TxContextFieldTag.CallerAddress
     )
@@ -37,8 +34,7 @@ def end_tx(instruction: Instruction):
     # Add gas_used * effective_tip to coinbase's balance
     base_fee = instruction.block_context_lookup_word(BlockContextFieldTag.BaseFee)
     effective_tip, _ = instruction.sub_word(tx_gas_price, base_fee)
-    reward, carry = instruction.mul_word_by_u64(effective_tip, gas_used)
-    instruction.constrain_zero(carry)
+    reward = instruction.mul_word_by_u64(effective_tip, gas_used)
     coinbase_word = instruction.block_context_lookup_word(BlockContextFieldTag.Coinbase)
     coinbase = instruction.word_to_address(coinbase_word)
     instruction.add_balance(coinbase, [reward])

--- a/src/zkevm_specs/evm_circuit/instruction.py
+++ b/src/zkevm_specs/evm_circuit/instruction.py
@@ -567,7 +567,7 @@ class Instruction:
 
         return Word((diff_lo, diff_hi)), FQ(borrow_hi)
 
-    def mul_word_by_u64(self, multiplicand: Word, multiplier: Expression) -> Tuple[Word, FQ]:
+    def mul_word_by_u64(self, multiplicand: Word, multiplier: Expression) -> Word:
         multiplicand_lo, multiplicand_hi = multiplicand.to_lo_hi()
 
         quotient_lo, product_lo = divmod((multiplicand_lo * multiplier.expr()).n, 1 << 128)
@@ -575,9 +575,9 @@ class Instruction:
             (multiplicand_hi * multiplier.expr() + quotient_lo).n, 1 << 128
         )
 
-        product_bytes = product_lo.to_bytes(16, "little") + product_hi.to_bytes(16, "little")
+        self.constrain_zero(FQ(quotient_hi))
 
-        return Word((FQ(product_lo), FQ(product_hi))), FQ(quotient_hi)
+        return Word((FQ(product_lo), FQ(product_hi)))
 
     def mul_add_words(self, a: Word, b: Word, c: Word, d: Word) -> FQ:
         """


### PR DESCRIPTION
# Changes
- Added zero equality constraint for `quotient_hi`

- Fix to return with `product_bytes` which was there but unused

# Description
As mentioned in https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_word_u64.rs#L15-L16, `mul_word_by_u64` gadget assumes that there will be no overflow.

And this is implicitly checked in [the code below](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/util/math_gadget/mul_word_u64.rs#L50-L53).

However, there is no such constraint inside the `mul_word_by_u64` gadget, but instead it returns the carry and checks outside the gadget. I think this is an inconsistent (with the zkevm-circuits code) implementation, so I made the fix.

# Note
Sorry for the weird branch name. I had the same motivation, but at first, I made a wrong way of change.