### PR TITLE
Fully implement PUSHn

### DIFF
--- a/src/zkevm_specs/evm_circuit/execution/push.py
+++ b/src/zkevm_specs/evm_circuit/execution/push.py
@@ -1,3 +1,4 @@
+from ...util import N_BYTES_PROGRAM_COUNTER
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 
@@ -5,15 +6,19 @@ from ..opcode import Opcode
 def push(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     num_pushed = opcode - Opcode.PUSH1 + 1
-    num_additional_pushed = num_pushed - 1
+    code_length = instruction.bytecode_length(instruction.curr.code_hash)
+    code_length_left = code_length - instruction.curr.program_counter - 1
+    is_out_of_bound, _ = instruction.compare(code_length_left, num_pushed, N_BYTES_PROGRAM_COUNTER)
+    num_padding = is_out_of_bound * (num_pushed - code_length_left)
 
     value = instruction.stack_push()
     value_le_bytes = value.to_le_bytes()
-    selectors = instruction.continuous_selectors(num_additional_pushed, 31)
+    is_pushed = instruction.continuous_selectors(num_pushed, 32)
+    is_padding = instruction.continuous_selectors(num_padding, 32)
 
     for idx in range(32):
         index = instruction.curr.program_counter + num_pushed - idx
-        if idx == 0 or selectors[idx - 1] == 1:
+        if is_pushed[idx] * (1 - is_padding[idx]) == 1:
             instruction.constrain_equal(
                 value_le_bytes[idx], instruction.opcode_lookup_at(index, False)
             )

--- a/src/zkevm_specs/evm_circuit/execution/stop.py
+++ b/src/zkevm_specs/evm_circuit/execution/stop.py
@@ -1,4 +1,4 @@
-from ...util import FQ
+from ...util import FQ, N_BYTES_PROGRAM_COUNTER
 from ..instruction import Instruction, Transition
 from ..table import CallContextFieldTag
 from ..execution_state import ExecutionState
@@ -7,9 +7,13 @@ from ..execution_state import ExecutionState
 def stop(instruction: Instruction):
     # Note when transition to STOP, program_counter can only be increased by 1,
     # (JUMP* will always transit to JUMPDEST, then to STOP if any) so when opcode
-    # fetching is out of range, the program_counter must be equal to code_length.
+    # fetching is out of range, the program_counter must be greater or equal than code_length.
     code_length = instruction.bytecode_length(instruction.curr.code_hash)
-    is_out_of_range = instruction.is_equal(code_length, instruction.curr.program_counter)
+    out_of_range = instruction.compare(
+        code_length, instruction.curr.program_counter, N_BYTES_PROGRAM_COUNTER
+    )
+    (lt, eq) = out_of_range
+    is_out_of_range = lt + eq
     if is_out_of_range == FQ(0):
         instruction.responsible_opcode_lookup(instruction.opcode_lookup(True))
 


### PR DESCRIPTION
Linked to issue #463 

------------ Objective
We intend here to support PUSHn with bytecode length inferior to n.

------------ Rational
In pushn, "selectors" are switches to enable or disable lookup arguments on the bytcode bytes as well as to check whether these are non-null if needs be. They directly depend on "n" of PUSHn.
We add to these "selectors", "counters" which have similar role but are a subset of them depending on the bytecode length. We added these extra switches to be able to easily check the various identities at the risk of some redundancy.

To support these changes, modifications in stop.py also had to be done. More precisely, the check "is_out_of_range had to be extended to support small bytecodes.