### PR TITLE
Feat/#454 implement ErrorOutOfGasCreate error state

### DIFF
--- a/specs/error_state/ErrorGasUintOverflow.md
+++ b/specs/error_state/ErrorGasUintOverflow.md
@@ -26,7 +26,7 @@ The `ErrGasUintOverflow` happens in
 
 but when the `ErrGasUintOverflow` happens in [`dynamicGas`](https://github.com/ethereum/go-ethereum/blob/793f0f9ec860f6f51e0cec943a268c10863097c7/core/vm/interpreter.go#L218), the error turns out [`ErrOutOfGas`](https://github.com/ethereum/go-ethereum/blob/793f0f9ec860f6f51e0cec943a268c10863097c7/core/vm/interpreter.go#LL221C17-L221C28).
 
-so we only need to care about follows case.
+so we only need to care about following cases.
 
 - [IntrinsicGas](https://github.com/ethereum/go-ethereum/blob/b946b7a13b749c99979e312c83dce34cac8dd7b1/core/state_transition.go#L67)
 - [Run](https://github.com/ethereum/go-ethereum/blob/b946b7a13b749c99979e312c83dce34cac8dd7b1/core/vm/interpreter.go#L105)

--- a/specs/error_state/ErrorOutOfGasCall.md
+++ b/specs/error_state/ErrorOutOfGasCall.md
@@ -35,4 +35,4 @@ gas_cost = (
 
 ## Code
 
-Please refer to `src/zkevm_specs/evm/execution/oog_call.py`.
+Please refer to `src/zkevm_specs/evm/execution/error_oog_call.py`.

--- a/specs/error_state/ErrorOutOfGasCreate.md
+++ b/specs/error_state/ErrorOutOfGasCreate.md
@@ -2,7 +2,7 @@
 
 ## Procedure
 
-Handle the corresponding out of gas errors for `CREATE` and `CREATE2` opcodes.
+Handle the corresponding out-of-gas error and the max size of initial bytecode error for `CREATE` and `CREATE2` opcodes.
 
 ### EVM behavior
 
@@ -38,10 +38,14 @@ else:
     )
 ```
 
+The limit of the max size of initial bytecode is `49,152` which is `2 * MAX_CODE_SIZE`
+
 ### Constraints
 
 1. Current opcode is `CREATE` or `CREATE2`.
-2. `gas_left < gas_cost`.
+2. At least one of below conditions is met:
+  - `gas_left < gas_cost`.
+  - `len(init_code) > MAX_INIT_CODE_SIZE`
 3. Current call fails.
 4. Common error constraints: 
   - Current call fails. 

--- a/specs/error_state/ErrorOutOfGasCreate.md
+++ b/specs/error_state/ErrorOutOfGasCreate.md
@@ -1,0 +1,54 @@
+# ErrorOutOfGasCreate state
+
+## Procedure
+
+Handle the corresponding out of gas errors for `CREATE` and `CREATE2` opcodes.
+
+### EVM behavior
+
+The gas cost of `CREATE`/`CREATE2` is:
+```
+GAS_COST_CREATE := 32000
+KECCAK_WORD_GAS_COST := 6
+GAS_COST_INITCODE_WORD := 2
+
+keccak_gas_cost = KECCAK_WORD_GAS_COST * size if op_id == CREATE2 else 0
+initcode_gas_cost = GAS_COST_INITCODE_WORD * size
+gas_cost = (
+    GAS_COST_CREATE
+    + memory_expansion_gas_cost
+    + keccak_gas_cost
+    + initcode_gas_cost
+)
+
+```
+
+The memory expansion gas cost is calculated as:
+
+```
+next_memory_word_size = (destination_offset + copy_byte_size + 31) // 32
+# `current_memory_word_size` is fetched from the execution step.
+if next_memory_word_size <= current_memory_word_size:
+    memory_expansion_gas_cost = 0
+else:
+    memory_expansion_gas_cost = (
+        3 * (next_memory_word_size - current_memory_word_size)
+        + next_memory_word_size * next_memory_word_size // 512
+        - current_memory_word_size * current_memory_word_size // 512
+    )
+```
+
+### Constraints
+
+1. Current opcode is `CREATE` or `CREATE2`.
+2. `gas_left < gas_cost`.
+3. Current call fails.
+4. Common error constraints: 
+  - Current call fails. 
+  - Constrain `rw_counter_end_of_reversion = rw_counter_end_of_step + reversible_counter`.
+  - If it's a root call, it transits to `EndTx`.
+  - If it is not root call, it restores caller's context by reading to `rw_table`, then does step state transition to it.
+
+## Code
+
+Please refer to `src/zkevm_specs/evm/execution/error_oog_create.py`.

--- a/specs/error_state/ErrorOutOfGasCreate.md
+++ b/specs/error_state/ErrorOutOfGasCreate.md
@@ -46,8 +46,7 @@ The limit of the max size of initial bytecode is `49,152` which is `2 * MAX_CODE
 2. At least one of below conditions is met:
   - `gas_left < gas_cost`.
   - `len(init_code) > MAX_INIT_CODE_SIZE`
-3. Current call fails.
-4. Common error constraints: 
+3. Common error constraints: 
   - Current call fails. 
   - Constrain `rw_counter_end_of_reversion = rw_counter_end_of_step + reversible_counter`.
   - If it's a root call, it transits to `EndTx`.

--- a/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
+++ b/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
@@ -2,7 +2,7 @@
 
 ## Procedure
 
-Handle the corresponding out of gas errors for `CREATE`, `CREATE2`, `RETURN` and `REVERT` opcodes due to memory expansion.
+Handle the corresponding out of gas errors for `RETURN` and `REVERT` opcodes due to memory expansion.
 
 ### EVM behavior
 
@@ -10,20 +10,8 @@ For the current `go-ethereum` code, the out of gas error may occur for `constant
 
 ```
 gas_cost = constant_gas + dynamic_gas
-```
 
-The constant gas is different for `CREATE`, `CREATE2`, `RETURN` and `REVERT`.
-
-```
-if opcode == CREATE or opcode == CREATE2:
-    constant_gas = 32000
-else:
-    constant_gas = 0
-```
-
-The dynamic gas is calculated as:
-
-```
+constant_gas = 0
 dynamic_gas = memory_expansion_cost
 ```
 
@@ -44,7 +32,7 @@ else:
 
 ### Constraints
 
-1. Current opcode is one of `CREATE`, `CREATE2`, `RETURN` and `REVERT`.
+1. Current opcode is one of `RETURN` and `REVERT`.
 2. Constrain `gas_left < gas_cost`.
 3. Current call must fail.
 4. If it's a root call, it transits to `EndTx`.
@@ -53,7 +41,7 @@ else:
 
 ### Lookups
 
-1. `2` stack lookups for `CREATE`, `CREATE2`, `RETURN` and `REVERT`.
+1. `2` stack lookups for `RETURN` and `REVERT`.
 2. `2` call context lookups for `is_success` and `rw_counter_end_of_reversion`.
 
 And restore context lookups for non-root call.

--- a/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
+++ b/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
@@ -11,9 +11,8 @@ For the current `go-ethereum` code, the out of gas error may occur for `constant
 ```
 gas_cost = constant_gas + dynamic_gas
 
-constant_gas = 0
-dynamic_gas = memory_expansion_cost
 ```
+Where `constant_gas` = 0 and `dynamic_gas` = memory_expansion_cost
 
 The memory expansion gas cost is calculated as:
 

--- a/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
+++ b/specs/error_state/ErrorOutOfGasDynamicMemoryExpansion.md
@@ -12,7 +12,7 @@ For the current `go-ethereum` code, the out of gas error may occur for `constant
 gas_cost = constant_gas + dynamic_gas
 
 ```
-Where `constant_gas` = 0 and `dynamic_gas` = memory_expansion_cost
+Where `constant_gas` = 0 and `dynamic_gas` = memory_expansion_cost.
 
 The memory expansion gas cost is calculated as:
 

--- a/specs/opcode/F0CREATE_F5CREATE2.md
+++ b/specs/opcode/F0CREATE_F5CREATE2.md
@@ -17,7 +17,7 @@ The following values are popped from the stack:
 If the initialization call is successful, the new address will be pushed to the stack. If not, 0 will be pushed instead.
 
 The gadget does several things in the caller's call context:
-1. Do following pre-checks, stack depth, sender's balance, sender's nonce and contract address existence. If any one of them fails, restores the caller's context.
+1. Perform the following pre-checks: check the stack depth, validate the sender's balance, verify the sender's nonce, and ensure the existence of the contract address. If any of these checks fail, restore the caller's context.
 2. Expands memory
 3. Add `new_address` to the access list
 4. Calculate gas cost for this step.
@@ -93,7 +93,7 @@ In both cases, it then pushes 1 word to the stack.
 If all the pre-checks pass, then
   - It checks that `callee.is_persistent = caller.is_persistent and caller.is_success`.
   - If the caller is not persistent, we need to propagate the `rw_counter_end_of_reversion` to make sure every state update in the new call has a corresponding reversion.
-  -  It stores the current call context by writing the current values `rw_table` and checks that the new call context is setup correctly by reading to `rw_table`, and then does a step state transition to the call and begins the execution o the initialization bytecode.
+  - It stores the current call context by writing the current values `rw_table` and checks that the new call context is setup correctly by reading to `rw_table`, and then does a step state transition to the call and begins the execution o the initialization bytecode.
 Otherwise, it restores the current call context.
 ## Code
 

--- a/specs/opcode/F0CREATE_F5CREATE2.md
+++ b/specs/opcode/F0CREATE_F5CREATE2.md
@@ -57,13 +57,16 @@ The `gas_cost` for the step is:
 
 ```
 GAS_COST_CREATE := 32000
-KECCAK_WORD_GAS_COST : 6
+KECCAK_WORD_GAS_COST := 6
+GAS_COST_INITCODE_WORD := 2
 
 keccak_gas_cost = KECCAK_WORD_GAS_COST * size if op_id == CREATE2 else 0
+initcode_gas_cost = GAS_COST_INITCODE_WORD * size
 gas_cost = (
     GAS_COST_CREATE
     + memory_expansion_gas_cost
     + keccak_gas_cost
+    + initcode_gas_cost
 )
 ```
 

--- a/specs/opcode/F0CREATE_F5CREATE2.md
+++ b/specs/opcode/F0CREATE_F5CREATE2.md
@@ -14,14 +14,14 @@ The following values are popped from the stack:
 3. `size` - The length of the initialization code, in bytes.
 4. `salt` - Only for `CREATE2`: salt for the hash that will determine the new address.
 
-If the initialization call is successful, the new address will be pushed to the stack.
-If not, 0 will be pushed instead.
+If the initialization call is successful, the new address will be pushed to the stack. If not, 0 will be pushed instead.
 
 The gadget does several things in the caller's call context:
-1. Expands memory
-2. Add `new_address` to the access list
-3. Calculate gas cost for this step.
-4. Uses EIP150 to calculate how much gas will remain in the caller's context.
+1. Do following pre-checks, stack depth, sender's balance, sender's nonce and contract address existence. If any one of them fails, restores the caller's context.
+2. Expands memory
+3. Add `new_address` to the access list
+4. Calculate gas cost for this step.
+5. Uses EIP150 to calculate how much gas will remain in the caller's context.
 
 The memory size is calculated as follows:
 
@@ -58,7 +58,7 @@ The `gas_cost` for the step is:
 ```
 GAS_COST_CREATE := 32000
 KECCAK_WORD_GAS_COST := 6
-GAS_COST_INITCODE_WORD := 2
+GAS_COST_INITCODE_WORD := 2  # EIP-3860
 
 keccak_gas_cost = KECCAK_WORD_GAS_COST * size if op_id == CREATE2 else 0
 initcode_gas_cost = GAS_COST_INITCODE_WORD * size
@@ -90,11 +90,11 @@ The circuit takes the starting `rw_counter` as next call's `call_id` to make sur
 It pops 3 words for `CREATE` and 4 words for `CREATE2` from the stack.
 In both cases, it then pushes 1 word to the stack.
 
-It then checks that `callee.is_persistent = caller.is_persistent and caller.is_success`.
-If the caller is not persistent, we need to propagate the `rw_counter_end_of_reversion` to make sure every state update in the new call has a corresponding reversion.
-
-It stores the current call context by writing the current values `rw_table` and checks that the new call context is setup correctly by reading to `rw_table`, and then does a step state transition to the call and begins the execution o the initialization bytecode.
-
+If all the pre-checks pass, then
+  - It checks that `callee.is_persistent = caller.is_persistent and caller.is_success`.
+  - If the caller is not persistent, we need to propagate the `rw_counter_end_of_reversion` to make sure every state update in the new call has a corresponding reversion.
+  -  It stores the current call context by writing the current values `rw_table` and checks that the new call context is setup correctly by reading to `rw_table`, and then does a step state transition to the call and begins the execution o the initialization bytecode.
+Otherwise, it restores the current call context.
 ## Code
 
 Please refer to `src/zkevm_specs/evm/execution/create.py`.

--- a/src/zkevm_specs/evm_circuit/execution/__init__.py
+++ b/src/zkevm_specs/evm_circuit/execution/__init__.py
@@ -75,6 +75,7 @@ from .error_invalid_creation_code import *
 from .error_oog_sha3 import *
 from .error_oog_static_memory_expansion import *
 from .error_oog_sload_sstore import *
+from .error_oog_create import *
 
 
 EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
@@ -150,6 +151,7 @@ EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.ErrorOutOfGasStaticMemoryExpansion: error_oog_static_memory_expansion,
     ExecutionState.ErrorOutOfGasSloadSstore: error_oog_sload_sstore,
     ExecutionState.ErrorReturnDataOutOfBound: error_return_data_out_of_bound,
+    ExecutionState.ErrorOutOfGasCREATE2: error_oog_create,
     # ExecutionState.ECRECOVER: ,
     # ExecutionState.SHA256: ,
     # ExecutionState.RIPEMD160: ,

--- a/src/zkevm_specs/evm_circuit/execution/__init__.py
+++ b/src/zkevm_specs/evm_circuit/execution/__init__.py
@@ -151,7 +151,7 @@ EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.ErrorOutOfGasStaticMemoryExpansion: error_oog_static_memory_expansion,
     ExecutionState.ErrorOutOfGasSloadSstore: error_oog_sload_sstore,
     ExecutionState.ErrorReturnDataOutOfBound: error_return_data_out_of_bound,
-    ExecutionState.ErrorOutOfGasCREATE2: error_oog_create,
+    ExecutionState.ErrorOutOfGasCREATE: error_oog_create,
     # ExecutionState.ECRECOVER: ,
     # ExecutionState.SHA256: ,
     # ExecutionState.RIPEMD160: ,

--- a/src/zkevm_specs/evm_circuit/execution/create.py
+++ b/src/zkevm_specs/evm_circuit/execution/create.py
@@ -65,10 +65,9 @@ def create(instruction: Instruction):
     # CREATE2 = gas cost of CREATE + GAS_COST_COPY_SHA3 * word_len
     # byte_code is only available in `return_revert`,
     # so the last part (GAS_COST_CODE_DEPOSIT * len(byte_code)) won't be calculated here
-    gas_left = instruction.curr.gas_left
-    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost
     word_len, _ = instruction.constant_divmod(size + FQ(31), FQ(32), N_BYTES_MEMORY_WORD_SIZE)
-    gas_cost += word_len * GAS_COST_INITCODE_WORD
+    gas_left = instruction.curr.gas_left
+    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost + word_len * GAS_COST_INITCODE_WORD
     if is_create2 == FQ(1):
         gas_cost += GAS_COST_COPY_SHA3 * word_len
     gas_available = gas_left - gas_cost

--- a/src/zkevm_specs/evm_circuit/execution/create.py
+++ b/src/zkevm_specs/evm_circuit/execution/create.py
@@ -224,6 +224,9 @@ def create(instruction: Instruction):
 
     # error cases
     if not is_precheck_ok or not not_address_collision or not has_init_code:
+        if not is_precheck_ok or not not_address_collision:
+            instruction.constrain_equal(is_success, FQ(0))
+
         for field_tag, expected_value in [
             (CallContextFieldTag.LastCalleeId, FQ(0)),
             (CallContextFieldTag.LastCalleeReturnDataOffset, FQ(0)),

--- a/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
@@ -21,7 +21,7 @@ def error_gas_uint_overflow(instruction: Instruction):
 
     (
         is_call,
-        _,
+        is_callcode,
         is_delegatecall,
         is_staticcall,
         is_create_flag,
@@ -36,7 +36,6 @@ def error_gas_uint_overflow(instruction: Instruction):
         is_log3,
         is_log4,
         is_sha3,
-        _,
         is_mload,
         is_mstore,
         is_mstore8,
@@ -61,7 +60,6 @@ def error_gas_uint_overflow(instruction: Instruction):
             Opcode.LOG3,
             Opcode.LOG4,
             Opcode.SHA3,
-            Opcode.EXP,
             Opcode.MLOAD,
             Opcode.MSTORE,
             Opcode.MSTORE8,
@@ -77,6 +75,7 @@ def error_gas_uint_overflow(instruction: Instruction):
         + is_returndatacopy
         + is_sha3
         + is_call
+        + is_callcode
         + is_delegatecall
         + is_staticcall
         + is_create_flag

--- a/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
@@ -1,3 +1,9 @@
+from zkevm_specs.util.param import (
+    GAS_COST_INITCODE_WORD,
+    GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
+    GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
+    N_BYTES_MEMORY_WORD_SIZE,
+)
 from ...util import (
     FQ,
     TxDataNonZeroGasEIP2028,
@@ -88,13 +94,10 @@ def error_gas_uint_overflow(instruction: Instruction):
         + is_return
         + is_revert
     )
+
     is_opcode_memory_size_overflow = (
         is_safe_mul_overflow
-    ) = (
-        is_call_gas_cost_overflow
-    ) = (
-        is_non_zero_calldata_gas_overflow
-    ) = is_zero_calldata_gas_overflow = is_eip3860_overflow = FQ(0)
+    ) = is_call_gas_cost_overflow = is_calldata_gas_overflow = is_initcode_gas_overflow = FQ(0)
 
     # IntrinsicGas
     # https://github.com/ethereum/go-ethereum/blob/b946b7a13b749c99979e312c83dce34cac8dd7b1/core/state_transition.go#L67
@@ -109,31 +112,41 @@ def error_gas_uint_overflow(instruction: Instruction):
         ]
         data_len = len(data)
 
-        def transaction_data_gas_overflow() -> tuple[bool, bool]:
+        def transaction_data_gas_overflow() -> tuple[FQ, FQ]:
             # zero and non-zero bytes are priced differently
             nz = len([byte for byte in data if byte != 0])
             gas = TxGasContractCreation if is_create == FQ(1) else TxGas
             is_non_zero_calldata_gas_overflow, _ = instruction.compare(
                 FQ(((MAX_U64 - gas) // TxDataNonZeroGasEIP2028)), FQ(nz), N_BYTES_U64
             )
-            gas += nz * TxDataNonZeroGasEIP2028
+            gas += nz * GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE
 
             # tx data zero gas overflow
             is_zero_calldata_gas_overflow = FQ(0)
             if is_non_zero_calldata_gas_overflow == FQ(0):
                 z = data_len - nz
                 is_zero_calldata_gas_overflow, _ = instruction.compare(
-                    FQ(((MAX_U64 - gas) // TxDataZeroGas)), FQ(z), N_BYTES_U64
+                    FQ(((MAX_U64 - gas) // GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE)), FQ(z), N_BYTES_U64
+                )
+                gas += z * GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE
+
+            # EIP-3860, extra gas cost for init code
+            is_initcode_gas_overflow = FQ(0)
+            if is_create == FQ(1):
+                len_words, _ = instruction.constant_divmod(data_len + FQ(31), FQ(32), N_BYTES_U64)
+                is_initcode_gas_overflow, _ = instruction.compare(
+                    FQ(((MAX_U64 - gas) // GAS_COST_INITCODE_WORD)), FQ(len_words), N_BYTES_U64
                 )
 
-            # TODO: Would like to support EIP 3860 in the future (See
-            # https://github.com/privacy-scaling-explorations/zkevm-specs/issues/421)
-            return (is_non_zero_calldata_gas_overflow, is_zero_calldata_gas_overflow)
+            return (
+                is_non_zero_calldata_gas_overflow + is_zero_calldata_gas_overflow,
+                is_initcode_gas_overflow,
+            )
 
         if data_len > 0:
             (
-                is_non_zero_calldata_gas_overflow,
-                is_zero_calldata_gas_overflow,
+                is_calldata_gas_overflow,
+                is_initcode_gas_overflow,
             ) = transaction_data_gas_overflow()
 
     # Run
@@ -151,9 +164,8 @@ def error_gas_uint_overflow(instruction: Instruction):
         is_opcode_memory_size_overflow
         + is_safe_mul_overflow
         + is_call_gas_cost_overflow
-        + is_non_zero_calldata_gas_overflow
-        + is_zero_calldata_gas_overflow
-        + is_eip3860_overflow
+        + is_calldata_gas_overflow
+        + is_initcode_gas_overflow
     )
     instruction.constrain_not_zero(FQ(is_overflow))
 

--- a/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_gas_uint_overflow.py
@@ -2,7 +2,6 @@ from zkevm_specs.util.param import (
     GAS_COST_INITCODE_WORD,
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
-    N_BYTES_MEMORY_WORD_SIZE,
 )
 from ...util import (
     FQ,
@@ -11,7 +10,6 @@ from ...util import (
     N_BYTES_U64,
     TxGas,
     TxGasContractCreation,
-    TxDataZeroGas,
 )
 from ..instruction import Instruction
 from ..table import CallContextFieldTag
@@ -23,7 +21,7 @@ def error_gas_uint_overflow(instruction: Instruction):
 
     (
         is_call,
-        is_callcode,
+        _,
         is_delegatecall,
         is_staticcall,
         is_create_flag,
@@ -38,7 +36,7 @@ def error_gas_uint_overflow(instruction: Instruction):
         is_log3,
         is_log4,
         is_sha3,
-        is_exp,
+        _,
         is_mload,
         is_mstore,
         is_mstore8,

--- a/src/zkevm_specs/evm_circuit/execution/error_oog_create.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_oog_create.py
@@ -3,14 +3,17 @@ from zkevm_specs.util.arithmetic import FQ
 from zkevm_specs.util.param import (
     GAS_COST_COPY_SHA3,
     GAS_COST_CREATE,
+    GAS_COST_CREATION_TX,
     GAS_COST_INITCODE_WORD,
+    GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
+    GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
     MAX_INIT_CODE_SIZE,
     N_BYTES_GAS,
     N_BYTES_MEMORY_WORD_SIZE,
     N_BYTES_U64,
 )
 from ..instruction import Instruction
-from ..table import RW
+from ..table import RW, CallContextFieldTag
 
 
 def error_oog_create(instruction: Instruction):
@@ -26,19 +29,33 @@ def error_oog_create(instruction: Instruction):
     size_word = instruction.stack_lookup(RW.Read, 2)
     offset, size = instruction.memory_offset_and_length(offset_word, size_word)
 
-    (_, memory_expansion_gas_cost) = instruction.memory_expansion(offset, size)
-    word_size, _ = instruction.constant_divmod(size + FQ(31), FQ(32), N_BYTES_MEMORY_WORD_SIZE)
+    is_root = instruction.call_context_lookup(CallContextFieldTag.IsRoot)
 
-    # ErrMaxInitCodeSizeExceeded
-    is_exceed_max_initcode_size, _ = instruction.compare(FQ(MAX_INIT_CODE_SIZE), size, N_BYTES_U64)
+    # gas cost calculation
+    if is_root == FQ(1):
+        tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
+        data = [instruction.tx_calldata_lookup(tx_id, FQ(idx)) for idx in range(0, size.n)]
+        data_len = len(data)
 
-    # gas cost
+        # gas cost, 16 gas per non-zero byte, 4 gas per zero byte
+        gas_cost = GAS_COST_CREATION_TX
+        nz = len([byte for byte in data if byte != 0])
+        gas_cost += nz * GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE
+        z = data_len - nz
+        gas_cost += z * GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE
+    else:
+        (_, memory_expansion_gas_cost) = instruction.memory_expansion(offset, size)
+        gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost
+
     # GAS_COST_INITCODE_WORD * word_size introduced in EIP-3860
-    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost + GAS_COST_INITCODE_WORD * word_size
-
+    word_size, _ = instruction.constant_divmod(size + FQ(31), FQ(32), N_BYTES_MEMORY_WORD_SIZE)
+    gas_cost += GAS_COST_INITCODE_WORD * word_size
     # gas cost for SHA3 calculation if it's a CREATE2 opcode
     if is_create2 == FQ(1):
         gas_cost += GAS_COST_COPY_SHA3 * word_size
+
+    # ErrMaxInitCodeSizeExceeded
+    is_exceed_max_initcode_size, _ = instruction.compare(FQ(MAX_INIT_CODE_SIZE), size, N_BYTES_U64)
 
     insufficient_gas, _ = instruction.compare(instruction.curr.gas_left, gas_cost, N_BYTES_GAS)
 

--- a/src/zkevm_specs/evm_circuit/execution/error_oog_create.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_oog_create.py
@@ -1,0 +1,58 @@
+from zkevm_specs.evm_circuit.opcode import Opcode
+from zkevm_specs.util.arithmetic import FQ, Word, WordOrValue
+from zkevm_specs.util.hash import EMPTY_CODE_HASH
+from zkevm_specs.util.param import (
+    GAS_COST_COPY_SHA3,
+    GAS_COST_CREATE,
+    GAS_COST_CREATION_TX,
+    GAS_COST_INITCODE_WORD,
+    MAX_U64,
+    N_BYTES_ACCOUNT_ADDRESS,
+    N_BYTES_GAS,
+    N_BYTES_MEMORY_ADDRESS,
+    N_BYTES_MEMORY_WORD_SIZE,
+    N_BYTES_STACK,
+    N_BYTES_U64,
+)
+from ..instruction import Instruction, Transition
+from ..table import RW, CallContextFieldTag, AccountFieldTag, CopyDataTypeTag, TxContextFieldTag
+
+
+# if root:
+#     gas_cost = TxGasContractCreation + tx_calldata_gas_cost (covered in uint64 overflow)
+# else:
+#     gas cost = GAS_COST_CREATE + memory expansion (moved from dynamic_mm_exp)
+# if create2:
+#     gas_cost += GAS_COST_COPY_SHA3 * memory_size
+# gas_cost += initcode_cost(init_code) (covered in uint64 overflow if root)
+
+# MAX_INITCODE_SIZE (moved to CREATE.py)
+
+
+def error_oog_create(instruction: Instruction):
+    # check opcode is CREATE or CREATE2
+    opcode = instruction.opcode_lookup(True)
+    is_create, is_create2 = instruction.pair_select(opcode, Opcode.CREATE, Opcode.CREATE2)
+
+    # Constrain opcode must be CREATE or CREATE2.
+    instruction.constrain_equal(is_create + is_create2, FQ(1))
+
+    # First 3 stacks are `value`, `offset` and `size` but we don't need `value` here.
+    offset_word = instruction.stack_lookup(RW.Read, 1)
+    size_word = instruction.stack_lookup(RW.Read, 2)
+    offset, size = instruction.memory_offset_and_length(offset_word, size_word)
+
+    (_, memory_expansion_gas_cost) = instruction.memory_expansion(offset, size)
+    word_size, _ = instruction.constant_divmod(size + FQ(31), FQ(32), N_BYTES_MEMORY_WORD_SIZE)
+
+    # gas cost
+    # GAS_COST_INITCODE_WORD * word_size introduced in EIP-3860
+    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost + GAS_COST_INITCODE_WORD * word_size
+
+    # gas cost for SHA3 calculation if it's a CREATE2 opcode
+    if is_create2 == FQ(1):
+        gas_cost += GAS_COST_COPY_SHA3 * word_size
+
+    instruction.constrain_error_state(
+        instruction.rw_counter_offset + instruction.curr.reversible_write_counter
+    )

--- a/src/zkevm_specs/evm_circuit/execution/error_oog_dynamic_memory_expansion.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_oog_dynamic_memory_expansion.py
@@ -1,5 +1,3 @@
-from zkevm_specs.evm_circuit.table import RW
-from zkevm_specs.util.param import GAS_COST_CREATE
 from ...util import FQ
 from ..instruction import Instruction
 from ..opcode import Opcode

--- a/src/zkevm_specs/evm_circuit/execution/error_oog_dynamic_memory_expansion.py
+++ b/src/zkevm_specs/evm_circuit/execution/error_oog_dynamic_memory_expansion.py
@@ -7,32 +7,22 @@ from ...util import N_BYTES_GAS
 
 
 def error_oog_dynamic_memory_expansion(instruction: Instruction):
-    # retrieve op code associated to oog constant error
+    # retrieve op code associated to oog error
     opcode = instruction.opcode_lookup(True)
-    is_create, is_create2, is_return, is_revert = instruction.multiple_select(
-        opcode, (Opcode.CREATE, Opcode.CREATE2, Opcode.RETURN, Opcode.REVERT)
-    )
+    is_return, is_revert = instruction.multiple_select(opcode, (Opcode.RETURN, Opcode.REVERT))
 
-    # Constrain opcode must be one of CREATE, CREATE2, RETURN or REVERT.
-    instruction.constrain_equal(is_create + is_create2 + is_return + is_revert, FQ(1))
-
-    constant_gas = 0
-    stack_offset = 0
-    if is_create + is_create2 == FQ(1):
-        constant_gas = GAS_COST_CREATE
-        # the first stack of CREATE/CREATE2 is `value`, so we plus 1 here.
-        # see specs/opcode/F0CREATE_F5CREATE2.md for more details.
-        stack_offset += 1
+    # Constrain opcode must be RETURN or REVERT.
+    instruction.constrain_equal(is_return + is_revert, FQ(1))
 
     # get gas cost of memory expansion
-    offset_word = instruction.stack_lookup(RW.Read, stack_offset)
-    size_word = instruction.stack_lookup(RW.Read, stack_offset + 1)
+    offset_word = instruction.stack_pop()
+    size_word = instruction.stack_pop()
     offset, size = instruction.memory_offset_and_length(offset_word, size_word)
     (_, memory_expansion_gas_cost) = instruction.memory_expansion(offset, size)
 
     # check gas left is less than total gas required
     gas_not_enough, _ = instruction.compare(
-        instruction.curr.gas_left, constant_gas + memory_expansion_gas_cost, N_BYTES_GAS
+        instruction.curr.gas_left, memory_expansion_gas_cost, N_BYTES_GAS
     )
     instruction.constrain_equal(gas_not_enough, FQ(1))
 

--- a/src/zkevm_specs/evm_circuit/execution_state.py
+++ b/src/zkevm_specs/evm_circuit/execution_state.py
@@ -121,7 +121,7 @@ class ExecutionState(IntEnum):
     # For CALL, CALLCODE, DELEGATECALL and STATICCALL opcodes which may run out of gas.
     ErrorOutOfGasCall = auto()
     # For CREATE and CREATE2 opcodes which may run out of gas.
-    ErrorOutOfGasCREATE2 = auto()
+    ErrorOutOfGasCREATE = auto()
     ErrorOutOfGasSELFDESTRUCT = auto()
 
     # Precompile's successful cases
@@ -393,7 +393,7 @@ class ExecutionState(IntEnum):
             ExecutionState.ErrorOutOfGasSHA3,
             ExecutionState.ErrorOutOfGasSloadSstore,
             ExecutionState.ErrorOutOfGasCall,
-            ExecutionState.ErrorOutOfGasCREATE2,
+            ExecutionState.ErrorOutOfGasCREATE,
             ExecutionState.ErrorOutOfGasSELFDESTRUCT,
         ]
 

--- a/src/zkevm_specs/evm_circuit/execution_state.py
+++ b/src/zkevm_specs/evm_circuit/execution_state.py
@@ -120,6 +120,7 @@ class ExecutionState(IntEnum):
     ErrorOutOfGasSloadSstore = auto()
     # For CALL, CALLCODE, DELEGATECALL and STATICCALL opcodes which may run out of gas.
     ErrorOutOfGasCall = auto()
+    # For CREATE and CREATE2 opcodes which may run out of gas.
     ErrorOutOfGasCREATE2 = auto()
     ErrorOutOfGasSELFDESTRUCT = auto()
 

--- a/src/zkevm_specs/evm_circuit/instruction.py
+++ b/src/zkevm_specs/evm_circuit/instruction.py
@@ -1301,26 +1301,6 @@ class Instruction:
             if x.n > y.n:
                 return (x, FQ(0))
             return (y, FQ(0))
-        # elif (is_delegatecall + is_staticcall) == FQ(1):
-        #     self.stack_pop()
-        #     self.stack_pop()
-        #     cd_offset = self.stack_pop()
-        #     cd_length = self.stack_pop()
-        #     (x, overflow) = self.calc_mem_size64(
-        #         self.stack_pop(),
-        #         self.stack_pop(),
-        #     )
-        #     if overflow == FQ(1):
-        #         return (FQ(0), FQ(1))
-        #     (y, overflow) = self.calc_mem_size64(
-        #          cd_offset,
-        #         cd_length,
-        #     )
-        #     if overflow == FQ(1):
-        #         return (FQ(0), FQ(1))
-        #     if x.n > y.n:
-        #         return (x, FQ(0))
-        #     return (y, FQ(0))
 
     # calcMemSize64 calculates the required memory size, and returns
     # the size and whether the result overflowed uint64

--- a/src/zkevm_specs/evm_circuit/instruction.py
+++ b/src/zkevm_specs/evm_circuit/instruction.py
@@ -1210,6 +1210,7 @@ class Instruction:
             is_call,
             is_delegatecall,
             is_staticcall,
+            is_callcode,
             is_return,
             is_revert,
             is_log0,
@@ -1233,6 +1234,7 @@ class Instruction:
                 Opcode.CALL,
                 Opcode.DELEGATECALL,
                 Opcode.STATICCALL,
+                Opcode.CALLCODE,
                 Opcode.RETURN,
                 Opcode.REVERT,
                 Opcode.LOG0,
@@ -1278,8 +1280,8 @@ class Instruction:
                 offset,
                 size,
             )
-        elif (is_delegatecall + is_staticcall + is_call) == FQ(1):
-            if is_call == FQ(1):
+        elif (is_delegatecall + is_staticcall + is_call + is_callcode) == FQ(1):
+            if is_call + is_callcode == FQ(1):
                 self.stack_pop()
             self.stack_pop()
             self.stack_pop()

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -116,6 +116,9 @@ MAX_COPY_BYTES = 32
 # max bytecode size, 24576 bytes
 MAX_CODE_SIZE = 24576
 
+# max bytecode size, 49152 (2 * MAX_CODE_SIZE) bytes
+MAX_INIT_CODE_SIZE = MAX_CODE_SIZE * 2
+
 # Maximum depth of call/create stack
 CALL_CREATE_DEPTH = 1024
 

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -84,6 +84,8 @@ GAS_COST_ACCESS_LIST_STORAGE = 1900
 GAS_COST_CODE_DEPOSIT = 200
 # Gas cost of re-entrancy sentry check introduced in EIP2200
 GAS_COST_SSTORE_SENTRY_EIP2200 = 2300
+# Gas cost of initial bytecode per word defined in EIP-3860
+GAS_COST_INITCODE_WORD = 2
 
 
 # Quotient for max refund of gas used

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -186,7 +186,7 @@ TESTING_DATA = (
         Transaction(
             caller_address=0xFE,
             callee_address=None,
-            gas=100000,  # TODO(amb) make more precise gas
+            gas=53000,
         ),
         CALLEE_WITH_NOTHING,
         True,
@@ -196,7 +196,7 @@ TESTING_DATA = (
         Transaction(
             caller_address=0xFE,
             callee_address=None,
-            gas=100000,  # TODO(amb) make more precise gas
+            gas=53000,
             value=1,
         ),
         CALLEE_WITH_NOTHING,
@@ -207,7 +207,7 @@ TESTING_DATA = (
         Transaction(
             caller_address=0xFE,
             callee_address=None,
-            gas=53580,  # TODO(amb) make more precise gas
+            gas=53584,
             call_data=bytes(gen_bytecode(True, 0, True).code),
         ),
         CALLEE_WITH_NOTHING,
@@ -218,7 +218,7 @@ TESTING_DATA = (
         Transaction(
             caller_address=0xFE,
             callee_address=None,
-            gas=53580,
+            gas=53584,
             value=1,
             call_data=bytes(gen_bytecode(True, 0, True).code),
         ),
@@ -230,7 +230,7 @@ TESTING_DATA = (
         Transaction(
             caller_address=0xFE,
             callee_address=None,
-            gas=53580,
+            gas=53584,
             value=1,
             call_data=bytes(gen_bytecode(False, 0, True).code),
         ),

--- a/tests/evm/test_create.py
+++ b/tests/evm/test_create.py
@@ -1,3 +1,4 @@
+from math import ceil
 import pytest
 import rlp
 from collections import namedtuple
@@ -20,7 +21,11 @@ from zkevm_specs.evm_circuit import (
 from zkevm_specs.evm_circuit.table import CopyDataTypeTag
 from zkevm_specs.evm_circuit.typing import CopyCircuit
 from zkevm_specs.util.hash import EMPTY_CODE_HASH, keccak256
-from zkevm_specs.util.param import GAS_COST_COPY_SHA3, GAS_COST_CREATE
+from zkevm_specs.util.param import (
+    GAS_COST_COPY_SHA3,
+    GAS_COST_CREATE,
+    GAS_COST_INITCODE_WORD,
+)
 from zkevm_specs.util import Word
 from zkevm_specs.util.typing import U256
 
@@ -89,9 +94,11 @@ def calc_gas_cost(
         - caller_ctx.memory_word_size * caller_ctx.memory_word_size
     ) // 512 + 3 * (next_memory_size - caller_ctx.memory_word_size)
 
+    init_code_gas_cost = ceil(size / 32) * GAS_COST_INITCODE_WORD
+
     # GAS_COST_CODE_DEPOSIT * (bytecode size) is not included here, it should be `return_revert``
     # extra gas cost for CREATE2
-    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost
+    gas_cost = GAS_COST_CREATE + memory_expansion_gas_cost + init_code_gas_cost
     if is_create2 == 1:
         gas_cost += GAS_COST_COPY_SHA3 * memory_size(0, size)
     gas_available = caller_ctx.gas_left - gas_cost

--- a/tests/evm/test_create.py
+++ b/tests/evm/test_create.py
@@ -211,21 +211,7 @@ def test_create_create2(
         caller_ctx,
         stack,
     )
-
     nonce = caller.nonce
-    is_success = is_return
-    is_reverted_by_caller = not caller_ctx.is_persistent and is_success
-    is_reverted_by_callee = not is_success
-    callee_is_persistent = caller_ctx.is_persistent and is_success
-    callee_rw_counter_end_of_reversion = (
-        80
-        if is_reverted_by_callee
-        else (
-            caller_ctx.rw_counter_end_of_reversion - (caller_ctx.reversible_write_counter + 1)
-            if is_reverted_by_caller
-            else 0
-        )
-    )
 
     if is_create2 == 1:
         preimage = (
@@ -265,6 +251,20 @@ def test_create_create2(
 
     is_precheck_ok = (
         (caller_balance >= stack.value) and (nonce > nonce - 1) and (stack_depth <= 1024)
+    )
+
+    is_success = is_precheck_ok and not_address_collision
+    is_reverted_by_caller = not caller_ctx.is_persistent and is_success
+    is_reverted_by_callee = not is_success
+    callee_is_persistent = caller_ctx.is_persistent and is_success
+    callee_rw_counter_end_of_reversion = (
+        80
+        if is_reverted_by_callee
+        else (
+            caller_ctx.rw_counter_end_of_reversion - (caller_ctx.reversible_write_counter + 1)
+            if is_reverted_by_caller
+            else 0
+        )
     )
 
     src_data = dict(

--- a/tests/evm/test_error_gas_uint_overflow.py
+++ b/tests/evm/test_error_gas_uint_overflow.py
@@ -92,10 +92,11 @@ def gen_testing_data():
         # CREATE/CREATE2
         Op(opcode=Opcode.CREATE, byte_code=Bytecode().create()),
         Op(opcode=Opcode.CREATE2, byte_code=Bytecode().create2()),
-        # CALL/DELEGATECALL/STATICCALL
-        # Op(opcode=Opcode.CALL, byte_code=Bytecode().call()),
+        # CALL/DELEGATECALL/STATICCALL/CALLCODE
+        Op(opcode=Opcode.CALL, byte_code=Bytecode().call()),
         Op(opcode=Opcode.DELEGATECALL, byte_code=Bytecode().delegatecall()),
         Op(opcode=Opcode.STATICCALL, byte_code=Bytecode().staticcall()),
+        Op(opcode=Opcode.CALLCODE, byte_code=Bytecode().callcode()),
     ]
     stacks = [
         Stack(gas=100, cd_offset=MAX_U64 + 1, cd_length=1, rd_offset=0, rd_length=32),
@@ -213,7 +214,7 @@ def test_error_gas_uint_overflow_root(
         .stack_read(caller_id, 1022, Word(stack.cd_length)) \
         .stack_read(caller_id, 1023, Word(salt))
         stack_pointer = 1020
-    elif opcode in [Opcode.CALL]:
+    elif opcode in [Opcode.CALL, Opcode.CALLCODE]:
         rw_table \
         .stack_read(caller_id, 1017, Word(stack.gas)) \
         .stack_read(caller_id, 1018, Word(any_address)) \

--- a/tests/evm/test_error_oog_create.py
+++ b/tests/evm/test_error_oog_create.py
@@ -1,0 +1,109 @@
+import pytest
+
+from zkevm_specs.evm_circuit import (
+    ExecutionState,
+    StepState,
+    verify_steps,
+    Tables,
+    CallContextFieldTag,
+    Block,
+    Bytecode,
+    RWDictionary,
+    Opcode,
+)
+from zkevm_specs.util import Word
+
+
+TESTING_DATA_IS_ROOT = (
+    # gas cost: 32000 + 60 (memory expansion) + (320/32) * 2 = 32080
+    # CREATE2 has extra keccak gas cost = (320/32) * 6 = 60
+    (True, Opcode.CREATE, 320, 320, 32079),
+    (True, Opcode.CREATE2, 320, 320, 32139),
+    (False, Opcode.CREATE, 320, 320, 32079),
+    (False, Opcode.CREATE2, 320, 320, 32139),
+)
+
+
+@pytest.mark.parametrize("is_root, opcode, offset, length, gas_left", TESTING_DATA_IS_ROOT)
+def test_error_oog_create(is_root: bool, opcode: Opcode, offset: int, length: int, gas_left: int):
+    reversible_write_counter = 2
+    rw_counter = 2 if is_root else 14
+    caller_id = 1 if is_root else 2
+    is_create2 = opcode == Opcode.CREATE2
+    if is_create2:
+        bytecode = Bytecode().push32(1).push32(offset).push32(length).push32(123).create2()
+        pc = 132
+        stack_pointer = 1020
+    else:
+        bytecode = Bytecode().push32(1).push32(offset).push32(length).create()
+        pc = 99
+        stack_pointer = 1021
+    rw_table = (
+        RWDictionary(rw_counter)
+        .stack_read(caller_id, stack_pointer + 1, Word(offset))
+        .stack_read(caller_id, stack_pointer + 2, Word(length))
+    )
+    bytecode_hash = Word(bytecode.hash())
+
+    rw_table.call_context_read(caller_id, CallContextFieldTag.IsSuccess, 0)
+
+    # fmt: off
+    if not is_root:
+        rw_table \
+            .call_context_read(2, CallContextFieldTag.CallerId, 1) \
+            .call_context_read(1, CallContextFieldTag.IsRoot, False) \
+            .call_context_read(1, CallContextFieldTag.IsCreate, True) \
+            .call_context_read(1, CallContextFieldTag.CodeHash, bytecode_hash) \
+            .call_context_read(1, CallContextFieldTag.ProgramCounter, pc + 1) \
+            .call_context_read(1, CallContextFieldTag.StackPointer, 1024) \
+            .call_context_read(1, CallContextFieldTag.GasLeft, gas_left) \
+            .call_context_read(1, CallContextFieldTag.MemorySize, 0) \
+            .call_context_read(1, CallContextFieldTag.ReversibleWriteCounter, reversible_write_counter) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeId, 2) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataOffset, 0) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataLength, 0)
+    # fmt: on
+
+    tables = Tables(
+        block_table=set(Block().table_assignments()),
+        tx_table=set(),
+        bytecode_table=set(bytecode.table_assignments()),
+        rw_table=set(rw_table.rws),
+    )
+
+    verify_steps(
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.ErrorOutOfGasCREATE2,
+                rw_counter=rw_counter,
+                call_id=caller_id,
+                is_root=is_root,
+                is_create=True,
+                code_hash=bytecode_hash,
+                program_counter=pc,
+                stack_pointer=stack_pointer,
+                gas_left=gas_left,
+                reversible_write_counter=reversible_write_counter,
+            ),
+            StepState(
+                execution_state=ExecutionState.EndTx,
+                rw_counter=rw_table.rw_counter + reversible_write_counter,
+                call_id=1,
+            )
+            if is_root is True
+            else StepState(
+                execution_state=ExecutionState.STOP,
+                rw_counter=rw_table.rw_counter + reversible_write_counter,
+                call_id=1,
+                is_root=False,
+                is_create=True,
+                code_hash=bytecode_hash,
+                program_counter=pc + 1,
+                stack_pointer=1024,
+                gas_left=gas_left,
+                memory_word_size=0,
+                reversible_write_counter=reversible_write_counter,
+            ),
+        ],
+    )

--- a/tests/evm/test_error_oog_create.py
+++ b/tests/evm/test_error_oog_create.py
@@ -102,7 +102,7 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
         tables=tables,
         steps=[
             StepState(
-                execution_state=ExecutionState.ErrorOutOfGasCREATE2,
+                execution_state=ExecutionState.ErrorOutOfGasCREATE,
                 rw_counter=rw_counter,
                 call_id=caller_id,
                 is_root=is_root,

--- a/tests/evm/test_error_oog_create.py
+++ b/tests/evm/test_error_oog_create.py
@@ -12,6 +12,7 @@ from zkevm_specs.evm_circuit import (
     Opcode,
 )
 from zkevm_specs.util import Word
+from zkevm_specs.util.param import MAX_INIT_CODE_SIZE
 
 
 TESTING_DATA_IS_ROOT = (
@@ -21,6 +22,9 @@ TESTING_DATA_IS_ROOT = (
     (Opcode.CREATE2, 320, 320, 32139),
     (Opcode.CREATE, 320, 320, 32079),
     (Opcode.CREATE2, 320, 320, 32139),
+    # bytecode size exceeds MAX_INIT_CODE_SIZE
+    (Opcode.CREATE, 0, MAX_INIT_CODE_SIZE + 1, int(5e6)),
+    (Opcode.CREATE2, 0, MAX_INIT_CODE_SIZE + 1, int(5e6)),
 )
 
 
@@ -55,7 +59,7 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
         .call_context_read(1, CallContextFieldTag.CodeHash, bytecode_hash) \
         .call_context_read(1, CallContextFieldTag.ProgramCounter, pc + 1) \
         .call_context_read(1, CallContextFieldTag.StackPointer, 1024) \
-        .call_context_read(1, CallContextFieldTag.GasLeft, gas_left) \
+        .call_context_read(1, CallContextFieldTag.GasLeft, 0) \
         .call_context_read(1, CallContextFieldTag.MemorySize, 0) \
         .call_context_read(1, CallContextFieldTag.ReversibleWriteCounter, reversible_write_counter) \
         .call_context_write(1, CallContextFieldTag.LastCalleeId, 2) \
@@ -94,7 +98,7 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
                 code_hash=bytecode_hash,
                 program_counter=pc + 1,
                 stack_pointer=1024,
-                gas_left=gas_left,
+                gas_left=0,
                 memory_word_size=0,
                 reversible_write_counter=reversible_write_counter,
             ),

--- a/tests/evm/test_error_oog_create.py
+++ b/tests/evm/test_error_oog_create.py
@@ -10,29 +10,47 @@ from zkevm_specs.evm_circuit import (
     Bytecode,
     RWDictionary,
     Opcode,
+    Transaction,
 )
 from zkevm_specs.util import Word
 from zkevm_specs.util.param import MAX_INIT_CODE_SIZE
 
 
+def gen_calldata(bytes_len: int) -> bytes:
+    calldata = []
+    calldata.extend([int(Opcode.PUSH32)] * bytes_len)
+    assert len(calldata) == bytes_len
+    return bytes(calldata)
+
+
 TESTING_DATA_IS_ROOT = (
     # gas cost: 32000 + 60 (memory expansion) + (320/32) * 2 = 32080
     # CREATE2 has extra keccak gas cost = (320/32) * 6 = 60
-    (Opcode.CREATE, 320, 320, 32079),
-    (Opcode.CREATE2, 320, 320, 32139),
-    (Opcode.CREATE, 320, 320, 32079),
-    (Opcode.CREATE2, 320, 320, 32139),
+    (Opcode.CREATE, 320, 320, 32079, False),
+    (Opcode.CREATE2, 320, 320, 32139, False),
     # bytecode size exceeds MAX_INIT_CODE_SIZE
-    (Opcode.CREATE, 0, MAX_INIT_CODE_SIZE + 1, int(5e6)),
-    (Opcode.CREATE2, 0, MAX_INIT_CODE_SIZE + 1, int(5e6)),
+    (Opcode.CREATE, 0, MAX_INIT_CODE_SIZE + 1, int(5e6), False),
+    (Opcode.CREATE2, 0, MAX_INIT_CODE_SIZE + 1, int(5e6), False),
+    # hit insufficient gas and MAX_INIT_CODE_SIZE
+    (Opcode.CREATE, 0, MAX_INIT_CODE_SIZE + 1, int(3e6), False),
+    (Opcode.CREATE2, 0, MAX_INIT_CODE_SIZE + 1, int(3e6), False),
+    ## Same cases, with is_root set to True
+    # gas cost: 53000 + 320 * 16 + (320/32) * 2 = 58140
+    (Opcode.CREATE, 320, 320, 58139, True),
+    (Opcode.CREATE2, 320, 320, 58199, True),
+    # To generate a size of (MAX_INIT_CODE_SIZE + 1) calldata would cause memory corrupted in the local env.
+    # So, to make ci and local test works, we ignore the cases if overflowed calldata needed.
+    # Those cases were verified by changing MAX_INIT_CODE_SIZE to a smaller number, like 320
+    # (Opcode.CREATE, 0, MAX_INIT_CODE_SIZE + 1, int(5e6), True),
+    # (Opcode.CREATE2, 0, MAX_INIT_CODE_SIZE + 1, int(5e6), True),
 )
 
 
-@pytest.mark.parametrize("opcode, offset, length, gas_left", TESTING_DATA_IS_ROOT)
-def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: int):
+@pytest.mark.parametrize("opcode, offset, length, gas_left, is_root", TESTING_DATA_IS_ROOT)
+def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: int, is_root: bool):
     reversible_write_counter = 2
     rw_counter = 14
-    caller_id = 2
+    caller_id = 1 if is_root is True else 2
     is_create2 = opcode == Opcode.CREATE2
     if is_create2:
         bytecode = Bytecode().push32(1).push32(offset).push32(length).push32(123).create2()
@@ -49,27 +67,33 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
     )
     bytecode_hash = Word(bytecode.hash())
 
+    rw_table.call_context_read(caller_id, CallContextFieldTag.IsRoot, is_root)
+    if is_root is True:
+        tx = Transaction(id=1, call_data=gen_calldata(length if length < MAX_INIT_CODE_SIZE else 1))
+        rw_table.call_context_read(caller_id, CallContextFieldTag.TxId, 1)
+
     rw_table.call_context_read(caller_id, CallContextFieldTag.IsSuccess, 0)
 
-    # fmt: off
-    rw_table \
-        .call_context_read(2, CallContextFieldTag.CallerId, 1) \
-        .call_context_read(1, CallContextFieldTag.IsRoot, False) \
-        .call_context_read(1, CallContextFieldTag.IsCreate, True) \
-        .call_context_read(1, CallContextFieldTag.CodeHash, bytecode_hash) \
-        .call_context_read(1, CallContextFieldTag.ProgramCounter, pc + 1) \
-        .call_context_read(1, CallContextFieldTag.StackPointer, 1024) \
-        .call_context_read(1, CallContextFieldTag.GasLeft, 0) \
-        .call_context_read(1, CallContextFieldTag.MemorySize, 0) \
-        .call_context_read(1, CallContextFieldTag.ReversibleWriteCounter, reversible_write_counter) \
-        .call_context_write(1, CallContextFieldTag.LastCalleeId, 2) \
-        .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataOffset, 0) \
-        .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataLength, 0)
-    # fmt: on
+    if is_root is False:
+        # fmt: off
+        rw_table \
+            .call_context_read(caller_id, CallContextFieldTag.CallerId, 1) \
+            .call_context_read(1, CallContextFieldTag.IsRoot, False) \
+            .call_context_read(1, CallContextFieldTag.IsCreate, True) \
+            .call_context_read(1, CallContextFieldTag.CodeHash, bytecode_hash) \
+            .call_context_read(1, CallContextFieldTag.ProgramCounter, pc + 1) \
+            .call_context_read(1, CallContextFieldTag.StackPointer, 1024) \
+            .call_context_read(1, CallContextFieldTag.GasLeft, 0) \
+            .call_context_read(1, CallContextFieldTag.MemorySize, 0) \
+            .call_context_read(1, CallContextFieldTag.ReversibleWriteCounter, reversible_write_counter) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeId, 2) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataOffset, 0) \
+            .call_context_write(1, CallContextFieldTag.LastCalleeReturnDataLength, 0)
+        # fmt: on
 
     tables = Tables(
         block_table=set(Block().table_assignments()),
-        tx_table=set(),
+        tx_table=set(tx.table_assignments()) if is_root is True else set(),
         bytecode_table=set(bytecode.table_assignments()),
         rw_table=set(rw_table.rws),
     )
@@ -81,7 +105,7 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
                 execution_state=ExecutionState.ErrorOutOfGasCREATE2,
                 rw_counter=rw_counter,
                 call_id=caller_id,
-                is_root=False,
+                is_root=is_root,
                 is_create=True,
                 code_hash=bytecode_hash,
                 program_counter=pc,
@@ -90,10 +114,16 @@ def test_error_oog_create(opcode: Opcode, offset: int, length: int, gas_left: in
                 reversible_write_counter=reversible_write_counter,
             ),
             StepState(
+                execution_state=ExecutionState.EndTx,
+                rw_counter=rw_table.rw_counter + reversible_write_counter,
+                call_id=1,
+            )
+            if is_root is True
+            else StepState(
                 execution_state=ExecutionState.STOP,
                 rw_counter=rw_table.rw_counter + reversible_write_counter,
                 call_id=1,
-                is_root=False,
+                is_root=is_root,
                 is_create=True,
                 code_hash=bytecode_hash,
                 program_counter=pc + 1,

--- a/tests/evm/test_error_oog_dynamic_memory_expansion.py
+++ b/tests/evm/test_error_oog_dynamic_memory_expansion.py
@@ -17,12 +17,8 @@ from zkevm_specs.util import Word
 TESTING_DATA_IS_ROOT = (
     (True, Opcode.RETURN, 32, 32, 5),
     (True, Opcode.REVERT, 32, 32, 5),
-    (True, Opcode.CREATE, 32, 32, 32001),
-    (True, Opcode.CREATE2, 32, 32, 32001),
     (False, Opcode.RETURN, 32, 32, 5),
     (False, Opcode.REVERT, 32, 32, 5),
-    (False, Opcode.CREATE, 32, 32, 32001),
-    (False, Opcode.CREATE2, 32, 32, 32001),
 )
 
 
@@ -39,24 +35,13 @@ def test_oog_dynamic_memory_expansion_root(
     pc = 67
     rw_counter = 2 if is_root else 14
     caller_id = 1 if is_root else 2
-    is_create = True if opcode == Opcode.CREATE or opcode == Opcode.CREATE2 else False
-    if is_create:
-        stack_pointer = 1021 - opcode == Opcode.CREATE2
-        bytecode = Bytecode().create()
-        rw_table = (
-            RWDictionary(rw_counter)
-            .stack_read(caller_id, stack_pointer + 1, Word(offset))
-            .stack_read(caller_id, stack_pointer + 2, Word(length))
-        )
-
-    else:
-        stack_pointer = 1021
-        bytecode = Bytecode().return_() if opcode == Opcode.RETURN else Bytecode().revert()
-        rw_table = (
-            RWDictionary(rw_counter - 1)
-            .stack_read(caller_id, stack_pointer, Word(offset))
-            .stack_read(caller_id, stack_pointer + 1, Word(length))
-        )
+    stack_pointer = 1022
+    bytecode = Bytecode().return_() if opcode == Opcode.RETURN else Bytecode().revert()
+    rw_table = (
+        RWDictionary(rw_counter)
+        .stack_read(caller_id, stack_pointer, Word(offset))
+        .stack_read(caller_id, stack_pointer + 1, Word(length))
+    )
 
     bytecode_hash = Word(bytecode.hash())
 
@@ -70,10 +55,10 @@ def test_oog_dynamic_memory_expansion_root(
         rw_table \
             .call_context_read(2, CallContextFieldTag.CallerId, 1) \
             .call_context_read(1, CallContextFieldTag.IsRoot, False) \
-            .call_context_read(1, CallContextFieldTag.IsCreate, is_create) \
+            .call_context_read(1, CallContextFieldTag.IsCreate, False) \
             .call_context_read(1, CallContextFieldTag.CodeHash, bytecode_hash) \
             .call_context_read(1, CallContextFieldTag.ProgramCounter, pc) \
-            .call_context_read(1, CallContextFieldTag.StackPointer, stack_pointer) \
+            .call_context_read(1, CallContextFieldTag.StackPointer, 1024) \
             .call_context_read(1, CallContextFieldTag.GasLeft, gas_left) \
             .call_context_read(1, CallContextFieldTag.MemorySize, memory_word_size) \
             .call_context_read(1, CallContextFieldTag.ReversibleWriteCounter, reversible_write_counter) \
@@ -94,10 +79,10 @@ def test_oog_dynamic_memory_expansion_root(
         steps=[
             StepState(
                 execution_state=ExecutionState.ErrorOutOfGasDynamicMemoryExpansion,
-                rw_counter=rw_counter if is_create else rw_counter - 1,
+                rw_counter=rw_counter,
                 call_id=caller_id,
                 is_root=is_root,
-                is_create=is_create,
+                is_create=False,
                 code_hash=bytecode_hash,
                 program_counter=0,
                 stack_pointer=stack_pointer,
@@ -108,7 +93,6 @@ def test_oog_dynamic_memory_expansion_root(
                 execution_state=ExecutionState.EndTx,
                 rw_counter=rw_table.rw_counter + reversible_write_counter,
                 call_id=1,
-                gas_left=0,
             )
             if is_root is True
             else StepState(
@@ -116,10 +100,10 @@ def test_oog_dynamic_memory_expansion_root(
                 rw_counter=rw_table.rw_counter + reversible_write_counter,
                 call_id=1,
                 is_root=False,
-                is_create=is_create,
+                is_create=False,
                 code_hash=bytecode_hash,
                 program_counter=pc,
-                stack_pointer=stack_pointer,
+                stack_pointer=1024,
                 gas_left=gas_left,
                 memory_word_size=memory_word_size,
                 reversible_write_counter=reversible_write_counter,


### PR DESCRIPTION
closed #454 and #459

---

[EIP-3860](https://eips.ethereum.org/EIPS/eip-3860#rules) includes
- limit the max size of init code to `49152` 
- add extra gas required for init code, `2 * len(ceil(init_code/32))`

This PR includes
1. move `CREATE/2` oog from `error_oog_dynamic_memory_expansion.py` to `error_oog_create.py`
2. support EIP-3860
   - `create.py` add  extra gas cost for init code. 
   - `begin_tx.py` add  extra gas cost for init code
   - `error_oog_create.py` handles errors of oog and max size of init code  (see [Rules 1 and 3](https://eips.ethereum.org/EIPS/eip-3860#rules)).    
   - `error_gas_uint_overflow.py` handles extra gas required for init code

