### PR TITLE
[WIP] Refactor/#499 clean up duplicated KeccakTable

### DIFF
--- a/src/zkevm_specs/pi_circuit.py
+++ b/src/zkevm_specs/pi_circuit.py
@@ -12,6 +12,7 @@ from .util import FQ, GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE, GAS_COST_TX_CALL_
 from .util import PUBLIC_INPUTS_BLOCK_LEN as BLOCK_LEN
 from .util import PUBLIC_INPUTS_TX_LEN as TX_LEN
 from .util import RLC, U8, U64, U160, U256, Expression, Word, WordOrValue, is_circuit_code
+from .util import KeccakTable
 
 
 @dataclass
@@ -73,32 +74,6 @@ class TxCallDataGasCostAccRow(TableRow):
 @dataclass(frozen=True)
 class FixedU16Row(TableRow):
     value: FQ
-
-
-class KeccakTable:
-    # The columns are: (is_enabled, input_rlc, input_len, output)
-    table: Set[Tuple[FQ, FQ, FQ, Word]]
-
-    def __init__(self):
-        self.table = set()
-        self.table.add((FQ.zero(), FQ.zero(), FQ.zero(), Word(0)))  # Add all 0s row
-
-    def add(self, input: bytes, keccak_randomness: FQ):
-        output = keccak(input)
-        self.table.add(
-            (
-                FQ.one(),
-                RLC(bytes(reversed(input)), keccak_randomness, n_bytes=len(input)).expr(),
-                FQ(len(input)),
-                Word(output),
-            )
-        )
-
-    def lookup(self, is_enabled: FQ, input_rlc: FQ, input_len: FQ, output: Word, assert_msg: str):
-        assert (is_enabled, input_rlc, input_len, output) in self.table, (
-            f"{assert_msg}: {(is_enabled, input_rlc, input_len, output)} "
-            + "not found in the lookup table"
-        )
 
 
 @dataclass

--- a/src/zkevm_specs/tx_circuit.py
+++ b/src/zkevm_specs/tx_circuit.py
@@ -11,12 +11,12 @@ from .util import (
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
     is_circuit_code,
+    KeccakTable,
 )
 from eth_keys import KeyAPI  # type: ignore
 import rlp  # type: ignore
 from eth_utils import keccak
 from .evm_circuit import TxContextFieldTag as Tag
-
 
 class Row:
     """
@@ -33,32 +33,6 @@ class Row:
         self.tag = tag
         self.index = index
         self.value = WordOrValue(value)
-
-
-class KeccakTable:
-    # The columns are: (is_enabled, input_rlc, input_len, output)
-    table: Set[Tuple[FQ, FQ, FQ, Word]]
-
-    def __init__(self):
-        self.table = set()
-        self.table.add((FQ(0), FQ(0), FQ(0), Word(0)))  # Add all 0s row
-
-    def add(self, input: bytes, keccak_randomness: FQ):
-        output = keccak(input)
-        self.table.add(
-            (
-                FQ(1),
-                RLC(bytes(reversed(input)), keccak_randomness, n_bytes=64).expr(),
-                FQ(len(input)),
-                Word(output),
-            )
-        )
-
-    def lookup(self, is_enabled: FQ, input_rlc: FQ, input_len: FQ, output: Word, assert_msg: str):
-        assert (is_enabled, input_rlc, input_len, output) in self.table, (
-            f"{assert_msg}: {(is_enabled, input_rlc, input_len, output)} "
-            + "not found in the lookup table"
-        )
 
 
 class WrongFieldInteger:

--- a/src/zkevm_specs/tx_circuit.py
+++ b/src/zkevm_specs/tx_circuit.py
@@ -18,6 +18,7 @@ import rlp  # type: ignore
 from eth_utils import keccak
 from .evm_circuit import TxContextFieldTag as Tag
 
+
 class Row:
     """
     Tx circuit row

--- a/src/zkevm_specs/util/tables.py
+++ b/src/zkevm_specs/util/tables.py
@@ -17,11 +17,12 @@ class KeccakTable:
 
     def add(self, input: bytes, keccak_randomness: FQ):
         output = keccak(input)
+        length = len(input)
         self.table.add(
             (
-                FQ(1),
-                RLC(bytes(reversed(input)), keccak_randomness, n_bytes=64).expr(),
-                FQ(len(input)),
+                FQ.one(),
+                RLC(bytes(reversed(input)), keccak_randomness, n_bytes=length).expr(),
+                FQ(length),
                 Word(output),
             )
         )

--- a/src/zkevm_specs/withdrawal_circuit.py
+++ b/src/zkevm_specs/withdrawal_circuit.py
@@ -11,6 +11,7 @@ from .util import (
     Word,
     Expression,
     is_circuit_code,
+    KeccakTable
 )
 import rlp  # type: ignore
 from .evm_circuit import lookup
@@ -88,33 +89,6 @@ class BlockTable:
             "value": value,
         }
         return lookup(BlockTableRow, self.table, query)
-
-
-class KeccakTable:
-    # The columns are: (is_enabled, input_rlc, input_len, output)
-    table: Set[Tuple[FQ, FQ, FQ, Word]]
-
-    def __init__(self):
-        self.table = set()
-        self.table.add((FQ(0), FQ(0), FQ(0), Word(0)))  # Add all 0s row
-
-    def add(self, input: bytes, keccak_randomness: FQ):
-        output = keccak(input)
-        length = len(input)
-        self.table.add(
-            (
-                FQ(1),
-                RLC(bytes(reversed(input)), keccak_randomness, n_bytes=length).expr(),
-                FQ(length),
-                Word(output),
-            )
-        )
-
-    def lookup(self, is_enabled: FQ, input_rlc: FQ, input_len: FQ, output: Word, assert_msg: str):
-        assert (is_enabled, input_rlc, input_len, output) in self.table, (
-            f"{assert_msg}: {(is_enabled, input_rlc, input_len, output)} "
-            + "not found in the lookup table"
-        )
 
 
 class Witness(NamedTuple):

--- a/src/zkevm_specs/withdrawal_circuit.py
+++ b/src/zkevm_specs/withdrawal_circuit.py
@@ -5,14 +5,7 @@ from zkevm_specs.evm_circuit.table import (
     BlockTableRow,
     BlockContextFieldTag,
 )
-from .util import (
-    FQ,
-    RLC,
-    Word,
-    Expression,
-    is_circuit_code,
-    KeccakTable
-)
+from .util import FQ, RLC, Word, Expression, is_circuit_code, KeccakTable
 import rlp  # type: ignore
 from .evm_circuit import lookup
 from eth_utils import keccak


### PR DESCRIPTION
WIP for #499. The PR currently replaces duplicated `KeccakTable` in `withdrawal_circuit.py`, `tx_circuit.py`, and `pi_circuit.py` with `KeccakTable` from `util/tables.py`.

However, it seems there is still duplication in `evm_circuit/table.py` and `evm_circuit/typing.py` that define `KeccakTableRow` and `KeccakCircuit`. 

The only difference between the two is the former has `is_enabled` binary first column and the latter has `state_tag` first column that is set to `2` showing that this row is the final part of a variable-length input.

should I try to combine the two? 